### PR TITLE
fix: 사고 과정 메시지를 항상 스레드에 표시

### DIFF
--- a/.docs/modules/claude_executor.md
+++ b/.docs/modules/claude_executor.md
@@ -31,15 +31,15 @@ _run_claude_in_session 함수를 캡슐화한 모듈입니다.
 - `_pop_pending(self, thread_ts)` (줄 233): pending 프롬프트를 꺼내고 제거
 - `_run_with_lock(self, session, prompt, msg_ts, channel, say, client, role, trello_card, is_existing_thread, initial_msg_ts, dm_channel_id, dm_thread_ts)` (줄 238): 락을 보유한 상태에서 실행 (while 루프로 pending 처리)
 - `_execute_once(self, session, prompt, msg_ts, channel, say, client, effective_role, trello_card, is_existing_thread, initial_msg_ts, is_trello_mode, thread_ts_override, dm_channel_id, dm_thread_ts)` (줄 309): 단일 Claude 실행
-- `_replace_thinking_message(self, client, channel, old_msg_ts, new_text, new_blocks, thread_ts)` (줄 570): 사고 과정 메시지를 최종 응답으로 교체 (chat_update)
-- `_handle_interrupted(self, last_msg_ts, main_msg_ts, is_trello_mode, trello_card, session, channel, client, dm_channel_id, dm_last_reply_ts)` (줄 595): 인터럽트로 중단된 실행의 사고 과정 메시지 정리
-- `_handle_success(self, result, session, effective_role, is_trello_mode, trello_card, channel, thread_ts, msg_ts, last_msg_ts, main_msg_ts, say, client, is_thread_reply, dm_channel_id, dm_thread_ts, dm_last_reply_ts)` (줄 641): 성공 결과 처리
-- `_handle_trello_success(self, result, response, session, trello_card, channel, thread_ts, main_msg_ts, say, client, is_list_run, usage_bar, dm_channel_id, dm_thread_ts, dm_last_reply_ts)` (줄 705): 트렐로 모드 성공 처리
-- `_handle_normal_success(self, result, response, channel, thread_ts, msg_ts, last_msg_ts, say, client, is_thread_reply, is_list_run, usage_bar)` (줄 818): 일반 모드(멘션) 성공 처리
-- `_handle_restart_marker(self, result, session, thread_ts, say)` (줄 930): 재기동 마커 처리
-- `_handle_list_run_marker(self, list_name, channel, thread_ts, say, client)` (줄 953): LIST_RUN 마커 처리 - 정주행 시작
-- `_handle_error(self, error, is_trello_mode, trello_card, session, channel, msg_ts, last_msg_ts, main_msg_ts, say, client, is_thread_reply, dm_channel_id, dm_last_reply_ts)` (줄 1022): 오류 결과 처리
-- `_handle_exception(self, e, is_trello_mode, trello_card, session, channel, msg_ts, thread_ts, last_msg_ts, main_msg_ts, say, client, is_thread_reply, dm_channel_id, dm_last_reply_ts)` (줄 1082): 예외 처리
+- `_replace_thinking_message(self, client, channel, old_msg_ts, new_text, new_blocks, thread_ts)` (줄 560): 사고 과정 메시지를 최종 응답으로 교체 (chat_update)
+- `_handle_interrupted(self, last_msg_ts, main_msg_ts, is_trello_mode, trello_card, session, channel, client, dm_channel_id, dm_last_reply_ts)` (줄 585): 인터럽트로 중단된 실행의 사고 과정 메시지 정리
+- `_handle_success(self, result, session, effective_role, is_trello_mode, trello_card, channel, thread_ts, msg_ts, last_msg_ts, main_msg_ts, say, client, is_thread_reply, dm_channel_id, dm_thread_ts, dm_last_reply_ts)` (줄 631): 성공 결과 처리
+- `_handle_trello_success(self, result, response, session, trello_card, channel, thread_ts, main_msg_ts, say, client, is_list_run, usage_bar, dm_channel_id, dm_thread_ts, dm_last_reply_ts)` (줄 695): 트렐로 모드 성공 처리
+- `_handle_normal_success(self, result, response, channel, thread_ts, msg_ts, last_msg_ts, say, client, is_thread_reply, is_list_run, usage_bar)` (줄 808): 일반 모드(멘션) 성공 처리
+- `_handle_restart_marker(self, result, session, thread_ts, say)` (줄 913): 재기동 마커 처리
+- `_handle_list_run_marker(self, list_name, channel, thread_ts, say, client)` (줄 936): LIST_RUN 마커 처리 - 정주행 시작
+- `_handle_error(self, error, is_trello_mode, trello_card, session, channel, msg_ts, last_msg_ts, main_msg_ts, say, client, is_thread_reply, dm_channel_id, dm_last_reply_ts)` (줄 1005): 오류 결과 처리
+- `_handle_exception(self, e, is_trello_mode, trello_card, session, channel, msg_ts, thread_ts, last_msg_ts, main_msg_ts, say, client, is_thread_reply, dm_channel_id, dm_last_reply_ts)` (줄 1065): 예외 처리
 
 ## 함수
 

--- a/src/seosoyoung/handlers/mention.py
+++ b/src/seosoyoung/handlers/mention.py
@@ -530,9 +530,10 @@ def register_mention_handlers(app, dependencies: dict):
             )
             initial_msg_ts = initial_msg["ts"]
         else:
-            # 채널에서 최초 멘션: 채널 루트에 응답
+            # 채널에서 최초 멘션: M(멘션 메시지)의 스레드에 답글
             initial_msg = client.chat_postMessage(
                 channel=channel,
+                thread_ts=session_thread_ts,
                 text=initial_text,
                 blocks=[{
                     "type": "section",

--- a/tests/test_intervention.py
+++ b/tests/test_intervention.py
@@ -585,8 +585,8 @@ class TestNormalSuccessWithReplace:
         call_kwargs = mock_replace.call_args
         assert call_kwargs[1]["thread_ts"] == "thread_1"
 
-    def test_channel_root_success_passes_none_thread_ts(self):
-        """채널 루트 응답에서는 thread_ts=None으로 _replace_thinking_message 호출"""
+    def test_channel_root_success_passes_thread_ts(self):
+        """채널 루트 응답에서도 P가 스레드에 있으므로 thread_ts 전달"""
         executor = make_executor()
         result = make_claude_result(output="짧은 응답")
         client = MagicMock()
@@ -601,7 +601,7 @@ class TestNormalSuccessWithReplace:
 
         mock_replace.assert_called_once()
         call_kwargs = mock_replace.call_args
-        assert call_kwargs[1]["thread_ts"] is None
+        assert call_kwargs[1]["thread_ts"] == "thread_1"
 
 
 class TestTrelloSuccessWithReplace:


### PR DESCRIPTION
## Summary
- 채널에서 최초 멘션 시 사고 과정(P)이 채널 루트에 올라가던 문제 수정
- mention.py, executor.py에서 `thread_ts`를 항상 전달하여 P가 M의 스레드에 답글로 표시되도록 변경
- 전체 테스트 1160개 통과

## Test plan
- [x] test_intervention.py: 채널 루트 응답 시 thread_ts 전달 확인 테스트 업데이트
- [x] 전체 테스트 스위트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)