### PR TITLE
feat(soul-dashboard): tool grouping + orphan node connection

### DIFF
--- a/src/soul-dashboard/client/components/DetailView.tsx
+++ b/src/soul-dashboard/client/components/DetailView.tsx
@@ -15,6 +15,7 @@ import { ThinkingDetail } from "./detail/ThinkingDetail";
 import { ToolDetail } from "./detail/ToolDetail";
 import { SubAgentDetail } from "./detail/SubAgentDetail";
 import { ErrorDetail } from "./detail/ErrorDetail";
+import { ToolGroupDetail, type ToolGroupData } from "./detail/ToolGroupDetail";
 import { SectionLabel, CodeBlock } from "./detail/shared";
 
 // === Detail Router ===
@@ -190,7 +191,10 @@ export function DetailView() {
         )}
 
         {selectedCard && <CardDetail card={selectedCard} />}
-        {selectedEventNodeData && !selectedCard && (
+        {selectedEventNodeData && !selectedCard && selectedEventNodeData.nodeType === "tool_group" && (
+          <ToolGroupDetail data={selectedEventNodeData as ToolGroupData} />
+        )}
+        {selectedEventNodeData && !selectedCard && selectedEventNodeData.nodeType !== "tool_group" && (
           <EventNodeDetail data={selectedEventNodeData} />
         )}
       </div>

--- a/src/soul-dashboard/client/components/NodeGraph.tsx
+++ b/src/soul-dashboard/client/components/NodeGraph.tsx
@@ -207,6 +207,21 @@ function NodeGraphInner() {
     ({ nodes: selectedNodes }: OnSelectionChangeParams) => {
       if (selectedNodes.length === 1) {
         const nodeData = selectedNodes[0].data;
+        const nodeType = nodeData?.nodeType as string | undefined;
+
+        // tool_group 노드 → groupedCardIds 포함하여 이벤트 노드 데이터로 저장
+        if (nodeType === "tool_group") {
+          selectEventNode({
+            nodeType,
+            label: (nodeData?.label as string) ?? "",
+            content: (nodeData?.content as string) ?? "",
+            groupedCardIds: (nodeData?.groupedCardIds as string[]) ?? [],
+            toolName: (nodeData?.toolName as string) ?? undefined,
+            groupCount: (nodeData?.groupCount as number) ?? undefined,
+          });
+          return;
+        }
+
         const cardId = nodeData?.cardId as string | undefined;
         if (cardId) {
           selectCard(cardId);
@@ -214,7 +229,6 @@ function NodeGraphInner() {
         }
 
         // user/intervention 등 카드 기반이 아닌 노드 → 이벤트 노드 데이터 저장
-        const nodeType = nodeData?.nodeType as string | undefined;
         if (nodeType === "user" || nodeType === "intervention") {
           selectEventNode({
             nodeType,

--- a/src/soul-dashboard/client/components/detail/ToolGroupDetail.tsx
+++ b/src/soul-dashboard/client/components/detail/ToolGroupDetail.tsx
@@ -1,0 +1,204 @@
+/**
+ * ToolGroupDetail - 도구 그룹 노드 상세 뷰
+ *
+ * 그룹 노드를 클릭했을 때 그룹 내 모든 개별 도구 호출을 목록으로 표시합니다.
+ * 각 호출의 입력 파라미터 요약과 에러 여부를 보여줍니다.
+ */
+
+import type { DashboardCard } from "@shared/types";
+import { monoFont, SectionLabel } from "./shared";
+import { useDashboardStore } from "../../stores/dashboard-store";
+
+/** ToolGroupDetail에 전달되는 데이터 타입 (스토어의 selectedEventNodeData에서 추출) */
+export interface ToolGroupData {
+  nodeType: string;
+  label: string;
+  content: string;
+  groupedCardIds: string[];
+  toolName?: string;
+  groupCount?: number;
+}
+
+export function ToolGroupDetail({ data }: { data: ToolGroupData }) {
+  const cards = useDashboardStore((s) => s.cards);
+  const groupedCardIds = data.groupedCardIds ?? [];
+  const groupedCards = groupedCardIds
+    .map((id) => cards.find((c) => c.cardId === id))
+    .filter((c): c is DashboardCard => c !== undefined);
+
+  const toolName = data.toolName ?? "unknown";
+  const count = data.groupCount ?? groupedCards.length;
+  const errorCount = groupedCards.filter((c) => c.isError).length;
+
+  return (
+    <div style={{ padding: "16px", display: "flex", flexDirection: "column", gap: "12px" }}>
+      {/* Header */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "8px",
+        }}
+      >
+        <span style={{ fontSize: "16px" }}>📦</span>
+        <div
+          style={{
+            fontSize: "11px",
+            color: "#d97706",
+            textTransform: "uppercase",
+            letterSpacing: "0.05em",
+            fontWeight: 600,
+          }}
+        >
+          Tool Group
+        </div>
+        <span
+          style={{
+            marginLeft: "auto",
+            fontSize: "12px",
+            color: "#d97706",
+            fontWeight: 700,
+            padding: "2px 8px",
+            borderRadius: 4,
+            backgroundColor: "rgba(217, 119, 6, 0.12)",
+          }}
+        >
+          ×{count}
+        </span>
+      </div>
+
+      {/* Tool name */}
+      <div>
+        <SectionLabel>Tool</SectionLabel>
+        <div
+          style={{
+            fontSize: "14px",
+            color: "#e5e7eb",
+            fontWeight: 600,
+            fontFamily: monoFont,
+          }}
+        >
+          {toolName}
+        </div>
+      </div>
+
+      {/* Summary */}
+      <div>
+        <SectionLabel>Summary</SectionLabel>
+        <div style={{ fontSize: "12px", color: "#9ca3af" }}>
+          {count} calls
+          {errorCount > 0 && (
+            <span style={{ color: "#ef4444", marginLeft: "8px" }}>
+              ({errorCount} error{errorCount > 1 ? "s" : ""})
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Individual calls */}
+      <div>
+        <SectionLabel>Calls ({groupedCards.length})</SectionLabel>
+        <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+          {groupedCards.map((card, idx) => (
+            <div
+              key={card.cardId}
+              style={{
+                background: card.isError
+                  ? "rgba(239, 68, 68, 0.08)"
+                  : "rgba(0,0,0,0.3)",
+                borderRadius: "6px",
+                padding: "8px 10px",
+                borderLeft: `3px solid ${card.isError ? "#ef4444" : card.completed ? "#22c55e" : "#f59e0b"}`,
+              }}
+            >
+              {/* Call header */}
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "6px",
+                  marginBottom: "4px",
+                }}
+              >
+                <span style={{ fontSize: "10px", color: "#6b7280" }}>
+                  #{idx + 1}
+                </span>
+                <span
+                  style={{
+                    fontSize: "10px",
+                    fontFamily: monoFont,
+                    color: "#4b5563",
+                  }}
+                >
+                  {card.cardId}
+                </span>
+                {card.isError && (
+                  <span style={{ fontSize: "10px", color: "#ef4444", marginLeft: "auto" }}>
+                    ❌ Error
+                  </span>
+                )}
+                {!card.isError && card.completed && (
+                  <span style={{ fontSize: "10px", color: "#22c55e", marginLeft: "auto" }}>
+                    ✅
+                  </span>
+                )}
+                {!card.completed && (
+                  <span style={{ fontSize: "10px", color: "#f59e0b", marginLeft: "auto" }}>
+                    ⏳ running
+                  </span>
+                )}
+              </div>
+
+              {/* Input summary */}
+              {card.toolInput && (
+                <div
+                  style={{
+                    fontSize: "11px",
+                    color: "#9ca3af",
+                    fontFamily: monoFont,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    marginBottom: card.toolResult ? "4px" : 0,
+                  }}
+                >
+                  {summarizeInput(card.toolInput)}
+                </div>
+              )}
+
+              {/* Result summary */}
+              {card.toolResult !== undefined && (
+                <div
+                  style={{
+                    fontSize: "11px",
+                    color: card.isError ? "#fca5a5" : "#6b7280",
+                    fontFamily: monoFont,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  → {card.toolResult.length > 80 ? card.toolResult.slice(0, 77) + "..." : card.toolResult}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** 입력 파라미터를 한 줄 요약으로 변환 */
+function summarizeInput(input: Record<string, unknown>): string {
+  const keys = Object.keys(input);
+  if (keys.length === 0) return "(no input)";
+
+  // 주요 필드 우선: file_path, command, pattern, query, prompt, url
+  const priorityKeys = ["file_path", "command", "pattern", "query", "prompt", "url"];
+  const key = priorityKeys.find((k) => k in input) ?? keys[0];
+  const val = input[key];
+  const str = typeof val === "string" ? val : JSON.stringify(val);
+  const truncated = str && str.length > 60 ? str.slice(0, 57) + "..." : str;
+  return `${key}: ${truncated}`;
+}

--- a/src/soul-dashboard/client/lib/layout-engine.test.ts
+++ b/src/soul-dashboard/client/lib/layout-engine.test.ts
@@ -19,6 +19,7 @@ function makeToolCard(
   toolName: string,
   completed = true,
   toolResult?: string,
+  parentCardId?: string,
 ): DashboardCard {
   return {
     cardId: id,
@@ -28,6 +29,7 @@ function makeToolCard(
     toolInput: { prompt: "test" },
     toolResult,
     completed,
+    parentCardId,
   };
 }
 
@@ -157,6 +159,202 @@ describe("buildGraph", () => {
         (e) => e.source === interventionNode.id || e.target === interventionNode.id,
       );
       expect(connectedEdges.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("도구 그룹핑 (Phase 2)", () => {
+    it("같은 parent + 같은 toolName 5개 → 1개 그룹 노드", () => {
+      const cards: DashboardCard[] = [
+        makeTextCard("t1", "Thinking"),
+        makeToolCard("r1", "Read", true, "content1", "t1"),
+        makeToolCard("r2", "Read", true, "content2", "t1"),
+        makeToolCard("r3", "Read", true, "content3", "t1"),
+        makeToolCard("r4", "Read", true, "content4", "t1"),
+        makeToolCard("r5", "Read", true, "content5", "t1"),
+      ];
+      const events: SoulSSEEvent[] = [
+        { type: "session", session_id: "s1" },
+      ];
+
+      const { nodes } = buildGraph(cards, events);
+
+      // tool_group 노드가 1개 생성되어야 함
+      const groupNodes = nodes.filter((n) => n.type === "tool_group");
+      expect(groupNodes).toHaveLength(1);
+
+      // 그룹 노드의 label에 횟수가 포함
+      expect(groupNodes[0].data.label).toContain("Read");
+      expect(groupNodes[0].data.label).toContain("5");
+
+      // groupedCardIds에 5개 카드 ID가 포함
+      expect(groupNodes[0].data.groupedCardIds).toHaveLength(5);
+      expect(groupNodes[0].data.groupedCardIds).toContain("r1");
+      expect(groupNodes[0].data.groupedCardIds).toContain("r5");
+      expect(groupNodes[0].data.groupCount).toBe(5);
+
+      // 개별 tool_call 노드는 없어야 함
+      const callNodes = nodes.filter((n) => n.type === "tool_call");
+      expect(callNodes).toHaveLength(0);
+
+      // tool_result 노드도 없어야 함
+      const resultNodes = nodes.filter((n) => n.type === "tool_result");
+      expect(resultNodes).toHaveLength(0);
+    });
+
+    it("1개 도구는 그룹화하지 않고 개별 노드 유지", () => {
+      const cards: DashboardCard[] = [
+        makeTextCard("t1", "Thinking"),
+        makeToolCard("r1", "Read", true, "content1", "t1"),
+      ];
+      const events: SoulSSEEvent[] = [
+        { type: "session", session_id: "s1" },
+      ];
+
+      const { nodes } = buildGraph(cards, events);
+
+      // tool_group 노드 없음
+      expect(nodes.filter((n) => n.type === "tool_group")).toHaveLength(0);
+      // 개별 tool_call 노드 1개
+      expect(nodes.filter((n) => n.type === "tool_call")).toHaveLength(1);
+    });
+
+    it("다른 toolName은 별도 그룹으로 분리", () => {
+      const cards: DashboardCard[] = [
+        makeTextCard("t1", "Thinking"),
+        makeToolCard("r1", "Read", true, "c1", "t1"),
+        makeToolCard("r2", "Read", true, "c2", "t1"),
+        makeToolCard("b1", "Bash", true, "c3", "t1"),
+        makeToolCard("b2", "Bash", true, "c4", "t1"),
+        makeToolCard("s1", "Skill", true, "c5", "t1"), // 1개 → 개별 노드
+      ];
+      const events: SoulSSEEvent[] = [
+        { type: "session", session_id: "s1" },
+      ];
+
+      const { nodes } = buildGraph(cards, events);
+
+      const groupNodes = nodes.filter((n) => n.type === "tool_group");
+      expect(groupNodes).toHaveLength(2); // Read×2, Bash×2
+
+      const callNodes = nodes.filter((n) => n.type === "tool_call");
+      expect(callNodes).toHaveLength(1); // Skill×1
+    });
+
+    it("그룹 노드의 groupedCardIds가 원본 카드 ID를 모두 포함", () => {
+      const cards: DashboardCard[] = [
+        makeTextCard("t1", "Thinking"),
+        makeToolCard("r1", "Read", true, "c1", "t1"),
+        makeToolCard("r2", "Read", true, "c2", "t1"),
+        makeToolCard("r3", "Read", true, "c3", "t1"),
+      ];
+      const events: SoulSSEEvent[] = [
+        { type: "session", session_id: "s1" },
+      ];
+
+      const { nodes } = buildGraph(cards, events);
+
+      const groupNode = nodes.find((n) => n.type === "tool_group");
+      expect(groupNode).toBeDefined();
+      expect(groupNode!.data.groupedCardIds).toEqual(["r1", "r2", "r3"]);
+    });
+  });
+
+  describe("고아 노드 연결 (Phase 3)", () => {
+    it("parentCardId 없는 도구가 lastThinkingNodeId에 연결", () => {
+      const cards: DashboardCard[] = [
+        makeTextCard("t1", "Thinking"),
+        makeToolCard("tool1", "Read", true, "content"),
+        // parentCardId 없음 → lastThinkingNodeId(t1)에 연결
+      ];
+      const events: SoulSSEEvent[] = [
+        { type: "session", session_id: "s1" },
+      ];
+
+      const { edges } = buildGraph(cards, events);
+
+      // tool_call이 thinking 노드에 연결되어 있는지
+      const thinkingToTool = edges.find(
+        (e) => e.source === "node-t1" && e.target === "node-tool1-call",
+      );
+      expect(thinkingToTool).toBeDefined();
+    });
+  });
+
+  describe("가상 thinking 노드 (Phase 4)", () => {
+    it("첫 text 카드 전에 tool 카드가 있으면 가상 thinking 노드 삽입", () => {
+      const cards: DashboardCard[] = [
+        makeToolCard("tool1", "Read", true, "content1"),
+        makeToolCard("tool2", "Bash", true, "content2"),
+        makeTextCard("t1", "Now thinking"),
+      ];
+      const events: SoulSSEEvent[] = [
+        { type: "session", session_id: "s1" },
+      ];
+
+      const { nodes, edges } = buildGraph(cards, events);
+
+      // 가상 thinking 노드가 생성되어야 함
+      const virtualNode = nodes.find((n) => n.id === "node-virtual-init");
+      expect(virtualNode).toBeDefined();
+      expect(virtualNode!.type).toBe("thinking");
+      expect(virtualNode!.data.label).toBe("Initial Tools");
+
+      // 가상 thinking 노드가 메인 플로우에 연결
+      const sessionToVirtual = edges.find(
+        (e) => e.target === "node-virtual-init",
+      );
+      expect(sessionToVirtual).toBeDefined();
+
+      // 도구 노드가 가상 thinking에 연결
+      const virtualToTool = edges.find(
+        (e) => e.source === "node-virtual-init",
+      );
+      expect(virtualToTool).toBeDefined();
+    });
+
+    it("첫 카드가 text이면 가상 thinking 노드 없음", () => {
+      const cards: DashboardCard[] = [
+        makeTextCard("t1", "Thinking first"),
+        makeToolCard("tool1", "Read", true, "content"),
+      ];
+      const events: SoulSSEEvent[] = [
+        { type: "session", session_id: "s1" },
+      ];
+
+      const { nodes } = buildGraph(cards, events);
+
+      const virtualNode = nodes.find((n) => n.id === "node-virtual-init");
+      expect(virtualNode).toBeUndefined();
+    });
+
+    it("고아 도구 그룹이 가상 thinking에 연결", () => {
+      const cards: DashboardCard[] = [
+        // 3개 orphan Read → 그룹 노드
+        makeToolCard("r1", "Read", true, "c1"),
+        makeToolCard("r2", "Read", true, "c2"),
+        makeToolCard("r3", "Read", true, "c3"),
+        makeTextCard("t1", "Now thinking"),
+      ];
+      const events: SoulSSEEvent[] = [
+        { type: "session", session_id: "s1" },
+      ];
+
+      const { nodes, edges } = buildGraph(cards, events);
+
+      // 가상 thinking 노드
+      const virtualNode = nodes.find((n) => n.id === "node-virtual-init");
+      expect(virtualNode).toBeDefined();
+
+      // 그룹 노드
+      const groupNode = nodes.find((n) => n.type === "tool_group");
+      expect(groupNode).toBeDefined();
+      expect(groupNode!.data.groupCount).toBe(3);
+
+      // 가상 thinking → 그룹 노드 엣지
+      const virtualToGroup = edges.find(
+        (e) => e.source === "node-virtual-init" && e.target === groupNode!.id,
+      );
+      expect(virtualToGroup).toBeDefined();
     });
   });
 

--- a/src/soul-dashboard/client/nodes/ToolGroupNode.tsx
+++ b/src/soul-dashboard/client/nodes/ToolGroupNode.tsx
@@ -1,0 +1,166 @@
+/**
+ * ToolGroupNode - 동일 도구 그룹 노드
+ *
+ * 같은 thinking 노드에 연결된 동일 도구 호출을 하나로 묶어 표시합니다.
+ * 예: "Read ×12" — 클릭 시 DetailPanel에서 개별 도구 결과를 확인할 수 있습니다.
+ */
+
+import { memo } from 'react';
+import { Handle, Position, type NodeProps, type Node } from '@xyflow/react';
+import type { GraphNodeData } from '../lib/layout-engine';
+
+type ToolGroupNodeType = Node<GraphNodeData, 'tool_group'>;
+
+const ACCENT = '#d97706'; // amber-600
+
+export const ToolGroupNode = memo(function ToolGroupNode({ data, selected }: NodeProps<ToolGroupNodeType>) {
+  const isStreaming = data.streaming;
+  const count = data.groupCount ?? 0;
+
+  return (
+    <div
+      data-testid="tool-group-node"
+      style={{
+        width: 260,
+        height: 84,
+        boxSizing: 'border-box',
+        background: 'rgba(17, 24, 39, 0.95)',
+        border: selected
+          ? `1px solid ${ACCENT}`
+          : '1px solid rgba(255,255,255,0.1)',
+        borderRadius: 8,
+        boxShadow: '0 2px 8px rgba(0,0,0,0.4)',
+        display: 'flex',
+        overflow: 'hidden',
+        ...(isStreaming && !selected
+          ? { animation: 'tool-call-pulse 2s infinite' }
+          : {}),
+      }}
+    >
+      {/* Left accent bar */}
+      <div
+        style={{
+          width: 4,
+          flexShrink: 0,
+          background: ACCENT,
+          borderRadius: '8px 0 0 8px',
+        }}
+      />
+
+      {/* Content area */}
+      <div style={{ flex: 1, padding: '10px 12px', minWidth: 0 }}>
+        {/* Header row */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            marginBottom: 6,
+          }}
+        >
+          <span style={{ fontSize: 14, flexShrink: 0 }}>📦</span>
+          <span
+            style={{
+              fontSize: 10,
+              color: '#6b7280',
+              textTransform: 'uppercase',
+              letterSpacing: '0.05em',
+              fontWeight: 600,
+            }}
+          >
+            Tool Group
+          </span>
+          {/* Count badge */}
+          <span
+            style={{
+              marginLeft: 'auto',
+              fontSize: 11,
+              color: ACCENT,
+              fontWeight: 700,
+              padding: '1px 6px',
+              borderRadius: 4,
+              backgroundColor: 'rgba(217, 119, 6, 0.12)',
+            }}
+          >
+            ×{count}
+          </span>
+        </div>
+
+        {/* Tool name */}
+        <div
+          style={{
+            fontSize: 13,
+            color: '#e5e7eb',
+            fontWeight: 600,
+            fontFamily: "'Cascadia Code', 'Fira Code', monospace",
+            marginBottom: 4,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {data.toolName || 'unknown'}
+        </div>
+
+        {/* Summary */}
+        <div
+          style={{
+            fontSize: 11,
+            color: '#6b7280',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {isStreaming ? 'running...' : `${count} calls grouped`}
+        </div>
+      </div>
+
+      {/* Handles */}
+      <Handle
+        type="target"
+        position={Position.Top}
+        id="top"
+        style={{
+          width: 8,
+          height: 8,
+          background: ACCENT,
+          border: '2px solid rgba(17, 24, 39, 0.95)',
+        }}
+      />
+      <Handle
+        type="target"
+        position={Position.Left}
+        id="left"
+        style={{
+          width: 8,
+          height: 8,
+          background: ACCENT,
+          border: '2px solid rgba(17, 24, 39, 0.95)',
+        }}
+      />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        id="bottom"
+        style={{
+          width: 8,
+          height: 8,
+          background: ACCENT,
+          border: '2px solid rgba(17, 24, 39, 0.95)',
+        }}
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        id="right"
+        style={{
+          width: 8,
+          height: 8,
+          background: ACCENT,
+          border: '2px solid rgba(17, 24, 39, 0.95)',
+        }}
+      />
+    </div>
+  );
+});

--- a/src/soul-dashboard/client/nodes/index.ts
+++ b/src/soul-dashboard/client/nodes/index.ts
@@ -11,6 +11,7 @@ import { UserNode } from './UserNode';
 import { ThinkingNode } from './ThinkingNode';
 import { ToolCallNode } from './ToolCallNode';
 import { ToolResultNode } from './ToolResultNode';
+import { ToolGroupNode } from './ToolGroupNode';
 import { ResponseNode } from './ResponseNode';
 import { SystemNode } from './SystemNode';
 import { InterventionNode } from './InterventionNode';
@@ -20,6 +21,7 @@ export const nodeTypes: NodeTypes = {
   thinking: ThinkingNode,
   tool_call: ToolCallNode,
   tool_result: ToolResultNode,
+  tool_group: ToolGroupNode,
   response: ResponseNode,
   system: SystemNode,
   intervention: InterventionNode,
@@ -30,6 +32,7 @@ export {
   ThinkingNode,
   ToolCallNode,
   ToolResultNode,
+  ToolGroupNode,
   ResponseNode,
   SystemNode,
   InterventionNode,

--- a/src/soul-dashboard/client/stores/dashboard-store.ts
+++ b/src/soul-dashboard/client/stores/dashboard-store.ts
@@ -28,11 +28,17 @@ export interface DashboardState {
   /** 선택된 카드 (상세 뷰에 표시) */
   selectedCardId: string | null;
 
-  /** 선택된 이벤트 노드 데이터 (user/intervention 노드용, 카드 기반이 아닌 노드) */
+  /** 선택된 이벤트 노드 데이터 (user/intervention/tool_group 노드용, 카드 기반이 아닌 노드) */
   selectedEventNodeData: {
     nodeType: string;
     label: string;
     content: string;
+    /** tool_group 노드: 그룹 내 카드 ID 목록 */
+    groupedCardIds?: string[];
+    /** tool_group 노드: 도구 이름 */
+    toolName?: string;
+    /** tool_group 노드: 그룹 내 도구 개수 */
+    groupCount?: number;
   } | null;
 
   /** 활성 세션의 카드 목록 (SSE 이벤트로 구성) */
@@ -66,8 +72,15 @@ export interface DashboardActions {
   // 카드 선택
   selectCard: (cardId: string | null) => void;
 
-  // 이벤트 노드 선택 (user/intervention 등 카드가 아닌 노드)
-  selectEventNode: (data: { nodeType: string; label: string; content: string } | null) => void;
+  // 이벤트 노드 선택 (user/intervention/tool_group 등 카드가 아닌 노드)
+  selectEventNode: (data: {
+    nodeType: string;
+    label: string;
+    content: string;
+    groupedCardIds?: string[];
+    toolName?: string;
+    groupCount?: number;
+  } | null) => void;
 
   // SSE 이벤트 처리
   processEvent: (event: SoulSSEEvent, eventId: number) => void;


### PR DESCRIPTION
## Summary
- **Issue #10 fix**: 동일 부모+도구명의 도구 호출 2개 이상을 하나의 그룹 노드로 묶어 25개 도구→3개 그룹으로 줄임 (2500px 높이 폭발 해결)
- **Issue #14 fix**: 고아 도구 노드를 가장 최근 thinking 노드에 연결하여 빈 화면 문제 해결, 첫 thinking 전 도구는 가상 "Initial Tools" 노드에 연결
- ToolGroupNode UI, ToolGroupDetail 패널, resolveToolParent 헬퍼 함수 추가
- 8개 새 유닛 테스트 추가 (184/184 전체 통과), E2E 8/8 통과

## Test plan
- [x] 도구 그룹핑: 동일 parent+toolName 5개 → 1개 그룹 노드
- [x] 고아 노드 연결: orphan tool → lastThinkingNodeId 연결
- [x] 가상 thinking 노드: 첫 카드 tool → 가상 thinking 생성
- [x] Vitest 184/184 통과
- [x] Playwright E2E 8/8 통과
- [x] Vite 빌드 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)