### PR TITLE
feat(slackbot): Soulstream 서버(4105)로 연결 전환

### DIFF
--- a/.docs/INDEX.md
+++ b/.docs/INDEX.md
@@ -30,8 +30,8 @@
 - [`claude/message_formatter.py`](modules/claude_message_formatter.md): 슬랙 메시지 포맷팅 유틸리티
 - [`claude/result_processor.py`](modules/claude_result_processor.md): Claude 실행 결과 처리
 - [`claude/sdk_compat.py`](modules/claude_sdk_compat.md): SDK 메시지 파싱 에러 호환 레이어
-- [`claude/service_adapter.py`](modules/claude_service_adapter.md): Claude Soul Service Adapter
-- [`claude/service_client.py`](modules/claude_service_client.md): Claude Soul Service HTTP + SSE 클라이언트
+- [`claude/service_adapter.py`](modules/claude_service_adapter.md): Soulstream Service Adapter
+- [`claude/service_client.py`](modules/claude_service_client.md): Soulstream Service HTTP + SSE 클라이언트
 - [`claude/session.py`](modules/claude_session.md): Claude Code 세션 관리
 - [`claude/session_context.py`](modules/claude_session_context.md): 세션 컨텍스트 주입
 - [`claude/session_validator.py`](modules/claude_session_validator.md): 세션 검증 모듈
@@ -123,24 +123,24 @@
 - `RoleConfig` (seosoyoung/slackbot/claude/engine_types.py:33): 역할별 도구 접근 설정
 - `EngineEventType` (seosoyoung/slackbot/claude/engine_types.py:51): 엔진 이벤트 타입
 - `EngineEvent` (seosoyoung/slackbot/claude/engine_types.py:72): 엔진에서 발행하는 단일 이벤트
-- `SoulHealthTracker` (seosoyoung/slackbot/claude/executor.py:38): Soul 서버 헬스 상태 추적
+- `SoulHealthTracker` (seosoyoung/slackbot/claude/executor.py:38): Soulstream 서버 헬스 상태 추적
 - `ClaudeExecutor` (seosoyoung/slackbot/claude/executor.py:154): Claude Code 실행기
 - `InstrumentedClaudeClient` (seosoyoung/slackbot/claude/instrumented_client.py:42): rate_limit_event 등 SDK가 skip하는 이벤트를 관찰할 수 있는 확장 클라이언트.
 - `PendingPrompt` (seosoyoung/slackbot/claude/intervention.py:17): 인터벤션 대기 중인 프롬프트 정보
 - `InterventionManager` (seosoyoung/slackbot/claude/intervention.py:34): 인터벤션 관리자
 - `ResultProcessor` (seosoyoung/slackbot/claude/result_processor.py:19): Claude 실행 결과를 처리하여 슬랙에 응답
 - `ParseAction` (seosoyoung/slackbot/claude/sdk_compat.py:16): MessageParseError 처리 결과
-- `ClaudeServiceAdapter` (seosoyoung/slackbot/claude/service_adapter.py:25): 원격 soul 서버 어댑터
-- `SSEEvent` (seosoyoung/slackbot/claude/service_client.py:31): Server-Sent Event 데이터
-- `ExecuteResult` (seosoyoung/slackbot/claude/service_client.py:38): soul 서버 실행 결과
-- `SoulServiceError` (seosoyoung/slackbot/claude/service_client.py:48): Soul Service 클라이언트 오류
-- `TaskConflictError` (seosoyoung/slackbot/claude/service_client.py:53): 태스크 충돌 오류 (이미 실행 중인 태스크 존재)
-- `TaskNotFoundError` (seosoyoung/slackbot/claude/service_client.py:58): 태스크를 찾을 수 없음
-- `TaskNotRunningError` (seosoyoung/slackbot/claude/service_client.py:63): 태스크가 실행 중이 아님
-- `RateLimitError` (seosoyoung/slackbot/claude/service_client.py:68): 동시 실행 제한 초과
-- `ConnectionLostError` (seosoyoung/slackbot/claude/service_client.py:73): SSE 연결 끊김 (재시도 실패)
-- `ExponentialBackoff` (seosoyoung/slackbot/claude/service_client.py:80): 지수 백오프 유틸리티
-- `SoulServiceClient` (seosoyoung/slackbot/claude/service_client.py:110): seosoyoung-soul 서버 HTTP + SSE 클라이언트
+- `ClaudeServiceAdapter` (seosoyoung/slackbot/claude/service_adapter.py:25): Soulstream 서버 어댑터
+- `SSEEvent` (seosoyoung/slackbot/claude/service_client.py:29): Server-Sent Event 데이터
+- `ExecuteResult` (seosoyoung/slackbot/claude/service_client.py:36): Soulstream 서버 실행 결과
+- `SoulServiceError` (seosoyoung/slackbot/claude/service_client.py:46): Soul Service 클라이언트 오류
+- `TaskConflictError` (seosoyoung/slackbot/claude/service_client.py:51): 태스크 충돌 오류 (이미 실행 중인 태스크 존재)
+- `TaskNotFoundError` (seosoyoung/slackbot/claude/service_client.py:56): 태스크를 찾을 수 없음
+- `TaskNotRunningError` (seosoyoung/slackbot/claude/service_client.py:61): 태스크가 실행 중이 아님
+- `RateLimitError` (seosoyoung/slackbot/claude/service_client.py:66): 동시 실행 제한 초과
+- `ConnectionLostError` (seosoyoung/slackbot/claude/service_client.py:71): SSE 연결 끊김 (재시도 실패)
+- `ExponentialBackoff` (seosoyoung/slackbot/claude/service_client.py:78): 지수 백오프 유틸리티
+- `SoulServiceClient` (seosoyoung/slackbot/claude/service_client.py:108): Soulstream 서버 HTTP + SSE 클라이언트
 - `Session` (seosoyoung/slackbot/claude/session.py:19): Claude Code 세션 정보
 - `SessionManager` (seosoyoung/slackbot/claude/session.py:41): 세션 매니저
 - `SessionRuntime` (seosoyoung/slackbot/claude/session.py:263): 세션 실행 상태 관리자
@@ -156,8 +156,8 @@
 - `OMConfig` (seosoyoung/slackbot/config.py:140): Observational Memory 설정
 - `ChannelObserverConfig` (seosoyoung/slackbot/config.py:166): Channel Observer 설정
 - `ClaudeConfig` (seosoyoung/slackbot/config.py:219): Claude 실행 모드 설정
-- `EmojiConfig` (seosoyoung/slackbot/config.py:229): 이모지 설정
-- `Config` (seosoyoung/slackbot/config.py:257): 애플리케이션 설정
+- `EmojiConfig` (seosoyoung/slackbot/config.py:232): 이모지 설정
+- `Config` (seosoyoung/slackbot/config.py:260): 애플리케이션 설정
 - `ChannelMessageCollector` (seosoyoung/slackbot/handlers/channel_collector.py:19): 관찰 대상 채널의 메시지를 수집하여 버퍼에 저장
 - `MentionTracker` (seosoyoung/slackbot/handlers/mention_tracker.py:20): 멘션으로 처리 중인 스레드를 추적 (TTL 기반 자동 만료)
 - `ParsedMarkers` (seosoyoung/slackbot/marker_parser.py:13): 파싱된 응용 마커

--- a/.docs/modules/claude_executor.md
+++ b/.docs/modules/claude_executor.md
@@ -12,17 +12,17 @@ _run_claude_in_session 함수를 캡슐화한 모듈입니다.
 
 실행 모드 (execution_mode):
 - local: 기존 방식. ClaudeRunner를 직접 사용하여 로컬에서 실행.
-- remote: seosoyoung-soul 서버에 HTTP/SSE로 위임하여 실행.
-         soul 서버 연결 실패 시 local 모드로 자동 폴백.
-         soul 복구 시 remote 모드로 자동 복귀.
+- remote: Soulstream 서버(독립 soul-server, 기본 포트 4105)에 HTTP/SSE로 위임하여 실행.
+         Soulstream 연결 실패 시 local 모드로 자동 폴백.
+         Soulstream 복구 시 remote 모드로 자동 복귀.
 
 ## 클래스
 
 ### `SoulHealthTracker`
 - 위치: 줄 38
-- 설명: Soul 서버 헬스 상태 추적
+- 설명: Soulstream 서버 헬스 상태 추적
 
-- remote 모드에서 soul 연결 가능 여부를 추적
+- remote 모드에서 Soulstream 연결 가능 여부를 추적
 - 실패 시 local 폴백, 복구 시 remote 복귀
 - 쿨다운 기반으로 헬스체크 빈도 제한
 
@@ -31,10 +31,10 @@ _run_claude_in_session 함수를 캡슐화한 모듈입니다.
 - `__init__(self, soul_url, cooldown)` (줄 46): 
 - `is_healthy(self)` (줄 55): 
 - `consecutive_failures(self)` (줄 59): 
-- `check_health(self)` (줄 62): Soul 서버 헬스체크 (쿨다운 적용)
+- `check_health(self)` (줄 62): Soulstream 헬스체크 (쿨다운 적용)
 - `mark_healthy(self)` (줄 95): 외부에서 healthy 상태로 강제 설정 (성공적 remote 실행 후)
 - `mark_unhealthy(self)` (줄 102): 외부에서 unhealthy 상태로 강제 설정 (remote 실행 중 연결 오류 시)
-- `_do_health_check(self)` (줄 109): HTTP GET /health 요청으로 soul 서버 가용성 확인
+- `_do_health_check(self)` (줄 109): HTTP GET /health 요청으로 Soulstream 서버 가용성 확인
 
 ### `ClaudeExecutor`
 - 위치: 줄 154
@@ -56,7 +56,7 @@ _run_claude_in_session 함수를 캡슐화한 모듈입니다.
 - `_register_session_id(self, thread_ts, session_id)` (줄 506): thread_ts ↔ session_id 매핑 등록 및 버퍼된 인터벤션 flush
 - `_unregister_session_id(self, thread_ts)` (줄 530): thread_ts ↔ session_id 매핑 해제
 - `_get_session_id(self, thread_ts)` (줄 539): thread_ts에 대응하는 session_id 조회
-- `_execute_remote(self, thread_ts, prompt)` (줄 544): Remote 모드: soul 서버에 실행을 위임
+- `_execute_remote(self, thread_ts, prompt)` (줄 544): Remote 모드: Soulstream 서버에 실행을 위임
 - `_process_result(self, presentation, result, thread_ts)` (줄 616): 실행 결과 처리
 
 ## 함수

--- a/.docs/modules/claude_intervention.md
+++ b/.docs/modules/claude_intervention.md
@@ -34,4 +34,4 @@ Slack 필드(channel, say, client 등)는 presentation 컨텍스트에 포함됩
 - `pop_pending(self, thread_ts)` (줄 51): pending 프롬프트를 꺼내고 제거
 - `pending_prompts(self)` (줄 57): pending_prompts dict 직접 접근 (테스트용)
 - `fire_interrupt_local(self, thread_ts)` (줄 61): Local 모드: 모듈 레지스트리에서 runner를 찾아 interrupt 전송
-- `fire_interrupt_remote(self, thread_ts, prompt, active_remote_requests, service_adapter)` (줄 75): Remote 모드: soul 서버에 HTTP intervene 요청
+- `fire_interrupt_remote(self, thread_ts, prompt, active_remote_requests, service_adapter)` (줄 75): Remote 모드: Soulstream에 HTTP intervene 요청

--- a/.docs/modules/claude_service_adapter.md
+++ b/.docs/modules/claude_service_adapter.md
@@ -4,9 +4,9 @@
 
 ## 개요
 
-Claude Soul Service Adapter
+Soulstream Service Adapter
 
-SoulServiceClient를 통해 원격 soul 서버에 Claude Code 실행을 위임하고,
+SoulServiceClient를 통해 Soulstream 서버에 Claude Code 실행을 위임하고,
 결과를 기존 ClaudeResult 포맷으로 변환합니다.
 
 ClaudeExecutor에서 local/remote 분기 시 remote 경로로 사용됩니다.
@@ -15,15 +15,15 @@ ClaudeExecutor에서 local/remote 분기 시 remote 경로로 사용됩니다.
 
 ### `ClaudeServiceAdapter`
 - 위치: 줄 25
-- 설명: 원격 soul 서버 어댑터
+- 설명: Soulstream 서버 어댑터
 
 executor의 _execute_once에서 remote 모드일 때 사용.
-SoulServiceClient로 실행하고 ClaudeResult로 변환합니다.
+SoulServiceClient로 Soulstream에 실행을 위임하고 ClaudeResult로 변환합니다.
 
 #### 메서드
 
 - `__init__(self, client, client_id)` (줄 32): 
-- `async execute(self, prompt, request_id, resume_session_id, on_progress, on_compact, on_debug, on_session)` (줄 38): Claude Code를 soul 서버에서 실행하고 ClaudeResult로 반환
+- `async execute(self, prompt, request_id, resume_session_id, on_progress, on_compact, on_debug, on_session)` (줄 38): Claude Code를 Soulstream에서 실행하고 ClaudeResult로 반환
 - `async intervene(self, request_id, text, user)` (줄 136): 실행 중인 태스크에 인터벤션 전송 (client_id/request_id 기반, 폴백용)
 - `async intervene_by_session(self, session_id, text, user)` (줄 163): session_id 기반 인터벤션 전송
 - `async close(self)` (줄 189): 클라이언트 종료

--- a/.docs/modules/claude_service_client.md
+++ b/.docs/modules/claude_service_client.md
@@ -4,67 +4,65 @@
 
 ## 개요
 
-Claude Soul Service HTTP + SSE 클라이언트
+Soulstream Service HTTP + SSE 클라이언트
 
-seosoyoung-soul 서버와 통신하는 HTTP 클라이언트.
+Soulstream 서버(독립 soul-server, 기본 포트 4105)와 통신하는 HTTP 클라이언트.
 CLAUDE_EXECUTION_MODE=remote일 때 사용됩니다.
-
-dorothy-bot의 claude_service_client.py 패턴을 seosoyoung에 맞게 적응.
 
 ## 클래스
 
 ### `SSEEvent`
-- 위치: 줄 31
+- 위치: 줄 29
 - 설명: Server-Sent Event 데이터
 
 ### `ExecuteResult`
-- 위치: 줄 38
-- 설명: soul 서버 실행 결과
+- 위치: 줄 36
+- 설명: Soulstream 서버 실행 결과
 
 ### `SoulServiceError` (Exception)
-- 위치: 줄 48
+- 위치: 줄 46
 - 설명: Soul Service 클라이언트 오류
 
 ### `TaskConflictError` (SoulServiceError)
-- 위치: 줄 53
+- 위치: 줄 51
 - 설명: 태스크 충돌 오류 (이미 실행 중인 태스크 존재)
 
 ### `TaskNotFoundError` (SoulServiceError)
-- 위치: 줄 58
+- 위치: 줄 56
 - 설명: 태스크를 찾을 수 없음
 
 ### `TaskNotRunningError` (SoulServiceError)
-- 위치: 줄 63
+- 위치: 줄 61
 - 설명: 태스크가 실행 중이 아님
 
 ### `RateLimitError` (SoulServiceError)
-- 위치: 줄 68
+- 위치: 줄 66
 - 설명: 동시 실행 제한 초과
 
 ### `ConnectionLostError` (SoulServiceError)
-- 위치: 줄 73
+- 위치: 줄 71
 - 설명: SSE 연결 끊김 (재시도 실패)
 
 ### `ExponentialBackoff`
-- 위치: 줄 80
+- 위치: 줄 78
 - 설명: 지수 백오프 유틸리티
 
 #### 메서드
 
-- `__init__(self, base_delay, max_delay, max_retries)` (줄 83): 
-- `get_delay(self)` (줄 94): 
-- `should_retry(self)` (줄 98): 
-- `increment(self)` (줄 101): 
-- `reset(self)` (줄 104): 
+- `__init__(self, base_delay, max_delay, max_retries)` (줄 81): 
+- `get_delay(self)` (줄 92): 
+- `should_retry(self)` (줄 96): 
+- `increment(self)` (줄 99): 
+- `reset(self)` (줄 102): 
 
 ### `SoulServiceClient`
-- 위치: 줄 110
-- 설명: seosoyoung-soul 서버 HTTP + SSE 클라이언트
+- 위치: 줄 108
+- 설명: Soulstream 서버 HTTP + SSE 클라이언트
 
 Task API를 사용하여 Claude Code를 원격 실행합니다.
 
 사용 예:
-    client = SoulServiceClient(base_url="http://localhost:3105", token="xxx")
+    client = SoulServiceClient(base_url="http://localhost:4105", token="xxx")
     result = await client.execute(
         client_id="seosoyoung_bot",
         request_id="thread_ts",
@@ -73,19 +71,19 @@ Task API를 사용하여 Claude Code를 원격 실행합니다.
 
 #### 메서드
 
-- `__init__(self, base_url, token)` (줄 124): 
-- `is_configured(self)` (줄 130): 
-- `async _get_session(self)` (줄 133): 
-- `_build_headers(self)` (줄 146): 
-- `async close(self)` (줄 155): 
-- `async __aenter__(self)` (줄 160): 
-- `async __aexit__(self, exc_type, exc_val, exc_tb)` (줄 163): 
-- `async execute(self, client_id, request_id, prompt, resume_session_id, on_progress, on_compact, on_debug, on_session)` (줄 168): Claude Code 실행 (SSE 스트리밍, 연결 끊김 시 자동 재연결)
-- `async intervene(self, client_id, request_id, text, user)` (줄 267): 실행 중인 태스크에 개입 메시지 전송
-- `async intervene_by_session(self, session_id, text, user)` (줄 295): session_id 기반 개입 메시지 전송
-- `async ack(self, client_id, request_id)` (줄 322): 결과 수신 확인
-- `async reconnect_stream(self, client_id, request_id, on_progress, on_compact, on_debug)` (줄 336): 태스크 SSE 스트림에 재연결
-- `async health_check(self)` (줄 364): 헬스 체크
-- `async _handle_sse_events(self, response, on_progress, on_compact, on_debug, on_session)` (줄 377): SSE 이벤트 스트림 처리
-- `async _parse_sse_stream(self, response)` (줄 450): SSE 스트림 파싱
-- `async _parse_error(self, response)` (줄 510): 에러 응답 파싱
+- `__init__(self, base_url, token)` (줄 122): 
+- `is_configured(self)` (줄 128): 
+- `async _get_session(self)` (줄 131): 
+- `_build_headers(self)` (줄 144): 
+- `async close(self)` (줄 153): 
+- `async __aenter__(self)` (줄 158): 
+- `async __aexit__(self, exc_type, exc_val, exc_tb)` (줄 161): 
+- `async execute(self, client_id, request_id, prompt, resume_session_id, on_progress, on_compact, on_debug, on_session)` (줄 166): Claude Code 실행 (SSE 스트리밍, 연결 끊김 시 자동 재연결)
+- `async intervene(self, client_id, request_id, text, user)` (줄 265): 실행 중인 태스크에 개입 메시지 전송
+- `async intervene_by_session(self, session_id, text, user)` (줄 293): session_id 기반 개입 메시지 전송
+- `async ack(self, client_id, request_id)` (줄 320): 결과 수신 확인
+- `async reconnect_stream(self, client_id, request_id, on_progress, on_compact, on_debug)` (줄 334): 태스크 SSE 스트림에 재연결
+- `async health_check(self)` (줄 362): 헬스 체크
+- `async _handle_sse_events(self, response, on_progress, on_compact, on_debug, on_session)` (줄 375): SSE 이벤트 스트림 처리
+- `async _parse_sse_stream(self, response)` (줄 448): SSE 스트림 파싱
+- `async _parse_error(self, response)` (줄 508): 에러 응답 파싱

--- a/.docs/modules/slackbot_config.md
+++ b/.docs/modules/slackbot_config.md
@@ -54,12 +54,14 @@
 - 위치: 줄 219
 - 설명: Claude 실행 모드 설정
 
+remote 모드에서 Soulstream 서버(독립 soul-server)에 연결합니다.
+
 ### `EmojiConfig`
-- 위치: 줄 229
+- 위치: 줄 232
 - 설명: 이모지 설정
 
 ### `Config`
-- 위치: 줄 257
+- 위치: 줄 260
 - 설명: 애플리케이션 설정
 
 설정 접근 방식:
@@ -68,14 +70,14 @@
 
 #### 메서드
 
-- `get_log_path()` (줄 281): 로그 경로
-- `get_session_path()` (줄 286): 세션 경로
-- `get_glossary_path()` (줄 291): 용어집 경로 (번역 시 고유명사 참조)
-- `get_narrative_path()` (줄 296): 대사 데이터 경로
-- `get_search_index_path()` (줄 301): 검색 인덱스 경로
-- `get_web_cache_path()` (줄 306): 웹 콘텐츠 캐시 경로
-- `get_memory_path()` (줄 311): 관찰 로그 저장 경로
-- `validate(cls)` (줄 319): 필수 환경변수 검증
+- `get_log_path()` (줄 284): 로그 경로
+- `get_session_path()` (줄 289): 세션 경로
+- `get_glossary_path()` (줄 294): 용어집 경로 (번역 시 고유명사 참조)
+- `get_narrative_path()` (줄 299): 대사 데이터 경로
+- `get_search_index_path()` (줄 304): 검색 인덱스 경로
+- `get_web_cache_path()` (줄 309): 웹 콘텐츠 캐시 경로
+- `get_memory_path()` (줄 314): 관찰 로그 저장 경로
+- `validate(cls)` (줄 322): 필수 환경변수 검증
 
 ## 함수
 

--- a/src/seosoyoung/slackbot/claude/intervention.py
+++ b/src/seosoyoung/slackbot/claude/intervention.py
@@ -83,7 +83,7 @@ class InterventionManager:
         pending_session_interventions: Optional[dict] = None,
         pending_session_lock: Optional[Any] = None,
     ):
-        """Remote 모드: soul 서버에 HTTP intervene 요청
+        """Remote 모드: Soulstream에 HTTP intervene 요청
 
         session_id가 확보되어 있으면 session_id 기반 인터벤션을 사용합니다.
         session_id가 없으면 (아직 미확보) 버퍼에 보관하거나,

--- a/src/seosoyoung/slackbot/claude/service_adapter.py
+++ b/src/seosoyoung/slackbot/claude/service_adapter.py
@@ -1,6 +1,6 @@
-"""Claude Soul Service Adapter
+"""Soulstream Service Adapter
 
-SoulServiceClient를 통해 원격 soul 서버에 Claude Code 실행을 위임하고,
+SoulServiceClient를 통해 Soulstream 서버에 Claude Code 실행을 위임하고,
 결과를 기존 ClaudeResult 포맷으로 변환합니다.
 
 ClaudeExecutor에서 local/remote 분기 시 remote 경로로 사용됩니다.
@@ -23,10 +23,10 @@ logger = logging.getLogger(__name__)
 
 
 class ClaudeServiceAdapter:
-    """원격 soul 서버 어댑터
+    """Soulstream 서버 어댑터
 
     executor의 _execute_once에서 remote 모드일 때 사용.
-    SoulServiceClient로 실행하고 ClaudeResult로 변환합니다.
+    SoulServiceClient로 Soulstream에 실행을 위임하고 ClaudeResult로 변환합니다.
     """
 
     def __init__(self, client: SoulServiceClient, client_id: str, *,
@@ -49,7 +49,7 @@ class ClaudeServiceAdapter:
         disallowed_tools: Optional[list[str]] = None,
         use_mcp: bool = True,
     ) -> ClaudeResult:
-        """Claude Code를 soul 서버에서 실행하고 ClaudeResult로 반환
+        """Claude Code를 Soulstream에서 실행하고 ClaudeResult로 반환
 
         Args:
             prompt: 실행할 프롬프트
@@ -122,7 +122,7 @@ class ClaudeServiceAdapter:
             return ClaudeResult(
                 success=False,
                 output="",
-                error=f"소울 서비스 오류: {e}",
+                error=f"Soulstream 오류: {e}",
             )
 
         except Exception as e:

--- a/src/seosoyoung/slackbot/claude/service_client.py
+++ b/src/seosoyoung/slackbot/claude/service_client.py
@@ -1,9 +1,7 @@
-"""Claude Soul Service HTTP + SSE 클라이언트
+"""Soulstream Service HTTP + SSE 클라이언트
 
-seosoyoung-soul 서버와 통신하는 HTTP 클라이언트.
+Soulstream 서버(독립 soul-server, 기본 포트 4105)와 통신하는 HTTP 클라이언트.
 CLAUDE_EXECUTION_MODE=remote일 때 사용됩니다.
-
-dorothy-bot의 claude_service_client.py 패턴을 seosoyoung에 맞게 적응.
 """
 
 import asyncio
@@ -36,7 +34,7 @@ class SSEEvent:
 
 @dataclass
 class ExecuteResult:
-    """soul 서버 실행 결과"""
+    """Soulstream 서버 실행 결과"""
     success: bool
     result: str
     claude_session_id: Optional[str] = None
@@ -108,12 +106,12 @@ class ExponentialBackoff:
 # === 클라이언트 ===
 
 class SoulServiceClient:
-    """seosoyoung-soul 서버 HTTP + SSE 클라이언트
+    """Soulstream 서버 HTTP + SSE 클라이언트
 
     Task API를 사용하여 Claude Code를 원격 실행합니다.
 
     사용 예:
-        client = SoulServiceClient(base_url="http://localhost:3105", token="xxx")
+        client = SoulServiceClient(base_url="http://localhost:4105", token="xxx")
         result = await client.execute(
             client_id="seosoyoung_bot",
             request_id="thread_ts",
@@ -260,8 +258,8 @@ class SoulServiceClient:
 
         return ExecuteResult(
             success=False,
-            result=f"소울 서비스 연결이 끊어졌습니다 ({backoff.max_retries}회 재시도 실패)",
-            error=f"소울 서비스 연결이 끊어졌습니다 ({backoff.max_retries}회 재시도 실패)",
+            result=f"Soulstream 연결이 끊어졌습니다 ({backoff.max_retries}회 재시도 실패)",
+            error=f"Soulstream 연결이 끊어졌습니다 ({backoff.max_retries}회 재시도 실패)",
         )
 
     async def intervene(
@@ -463,7 +461,7 @@ class SoulServiceClient:
         while True:
             try:
                 # asyncio.wait_for 타임아웃 제거: Claude 실행이 오래 걸릴 수 있음 (테스트 등).
-                # soul 서버가 주기적으로 keepalive 이벤트(:)를 보내므로 readline()은 블로킹되지 않음.
+                # Soulstream이 주기적으로 keepalive 이벤트(:)를 보내므로 readline()은 블로킹되지 않음.
                 # 전체 스트림 타임아웃도 제거: aiohttp.ClientTimeout(total=None).
                 line_bytes = await response.content.readline()
 
@@ -504,7 +502,7 @@ class SoulServiceClient:
                     f"[SSE] 네트워크 오류로 연결 끊김 (마지막 이벤트: {last_event_name}): {e}"
                 )
                 raise ConnectionLostError(
-                    f"소울 서비스 연결이 끊어졌습니다: {e}"
+                    f"Soulstream 연결이 끊어졌습니다: {e}"
                 )
 
     async def _parse_error(self, response: aiohttp.ClientResponse) -> str:

--- a/src/seosoyoung/slackbot/config.py
+++ b/src/seosoyoung/slackbot/config.py
@@ -217,10 +217,13 @@ class ChannelObserverConfig:
 
 @dataclass
 class ClaudeConfig:
-    """Claude 실행 모드 설정"""
+    """Claude 실행 모드 설정
+
+    remote 모드에서 Soulstream 서버(독립 soul-server)에 연결합니다.
+    """
 
     execution_mode: str = os.getenv("CLAUDE_EXECUTION_MODE", "local")
-    soul_url: str = os.getenv("SEOSOYOUNG_SOUL_URL", "http://localhost:3105")
+    soul_url: str = os.getenv("SEOSOYOUNG_SOUL_URL", "http://localhost:4105")
     soul_token: str = os.getenv("SEOSOYOUNG_SOUL_TOKEN", "")
     soul_client_id: str = os.getenv("SEOSOYOUNG_SOUL_CLIENT_ID", "seosoyoung_bot")
 

--- a/tests/claude/test_service_adapter.py
+++ b/tests/claude/test_service_adapter.py
@@ -142,7 +142,7 @@ class TestExecute:
         result = await adapter.execute(prompt="hello", request_id="thread-8")
 
         assert result.success is False
-        assert "소울 서비스 오류" in result.error
+        assert "Soulstream 오류" in result.error
 
     @pytest.mark.asyncio
     async def test_unexpected_error(self, adapter, mock_client):


### PR DESCRIPTION
## Summary
- 기존 내장 soul 서버(3105) 대신 독립 Soulstream 서버(4105)에 연결하도록 전환
- API가 동일하므로 코드 로직 변경 없이, 설정(기본 URL)과 docstring/주석만 업데이트
- 72 unit tests + 34 integration tests 전부 통과

## Changes
- `config.py`: `SEOSOYOUNG_SOUL_URL` 기본값 `http://localhost:3105` → `http://localhost:4105`
- `service_client.py`, `service_adapter.py`, `executor.py`, `intervention.py`: docstring/주석을 "Soulstream"으로 통일
- `test_service_adapter.py`: 변경된 에러 메시지("Soulstream 오류") 반영
- `.env`에 `SEOSOYOUNG_SOUL_URL=http://localhost:4105` 추가 (별도 반영)

## Test plan
- [x] service_client 단위 테스트 (36 tests)
- [x] service_adapter 단위 테스트 (16 tests)
- [x] executor remote 단위 테스트 (20 tests)
- [x] integration remote 테스트 (34 tests)
- [ ] 프로덕션 환경 슬랙 멘션 → Soulstream 세션 → 응답 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)