### PR TITLE
feat(caller-info): 슬랙 발신자 신원 통합 스키마 v1

### DIFF
--- a/src/seosoyoung/slackbot/auth.py
+++ b/src/seosoyoung/slackbot/auth.py
@@ -24,20 +24,44 @@ def check_permission(user_id: str, client) -> bool:
 
 
 def get_user_role(user_id: str, client) -> dict | None:
-    """사용자 역할 정보 반환
+    """사용자 역할 + 신원 정보 반환.
+
+    `users.info` API 1회 호출로 권한 판정과 caller_info 신원 필드를 함께 채운다
+    (정본 하나 원칙 — 분석 캐시 §2). 실패 시 None을 반환하여 호출자가 차단한다.
 
     Returns:
-        dict: {"user_id", "username", "role", "allowed_tools"} 또는 실패 시 None
+        dict: 성공 시 다음 키들을 포함
+            - user_id: Slack User ID (인자 그대로)
+            - username: user.name (소문자 ID, role 판정용)
+            - role: "admin" | "viewer"
+            - allowed_tools: 역할에 허용된 도구 목록
+            - display_name: profile.display_name → real_name 폴백, 둘 다 비면 ""
+            - avatar_url: profile.image_192 (없으면 "")
+            - email: profile.email (없으면 "")
+            - is_bot: 봇 사용자 여부
+        실패(SlackApiError, 네트워크, 응답 파싱 실패 등) 시 None.
     """
     try:
         result = client.users_info(user=user_id)
-        username = result["user"]["name"]
+        user = result["user"]
+        username = user["name"]
+        profile = user.get("profile", {}) or {}
         role = "admin" if username in Config.auth.admin_users else "viewer"
+        # display_name 폴백: profile.display_name → profile.real_name → ""
+        display_name = (
+            profile.get("display_name")
+            or profile.get("real_name")
+            or ""
+        )
         return {
             "user_id": user_id,
             "username": username,
             "role": role,
-            "allowed_tools": Config.auth.role_tools[role]
+            "allowed_tools": Config.auth.role_tools[role],
+            "display_name": display_name,
+            "avatar_url": profile.get("image_192", ""),
+            "email": profile.get("email", ""),
+            "is_bot": user.get("is_bot", False),
         }
     except Exception as e:
         logger.error(f"사용자 역할 조회 실패: user_id={user_id}, error={e}")

--- a/src/seosoyoung/slackbot/handlers/mention.py
+++ b/src/seosoyoung/slackbot/handlers/mention.py
@@ -428,12 +428,17 @@ def create_session_and_run_claude(
             except Exception as e:
                 logger.warning(f"after_execute hook 실패 (무시): {e}")
 
-    # 슬랙 호출 맥락으로부터 caller_info 조립 (Phase 4)
+    # 슬랙 호출 맥락으로부터 caller_info 조립 (통합 스키마 v1)
+    # user_info는 위 get_user_role 1회 호출의 결과 — display_name·avatar_url·email을
+    # 함께 들고 있어 별도 users.info 재호출 없이 신원 필드 채움 (정본 하나 원칙).
     from seosoyoung.slackbot.soulstream.caller_info import build_slack_caller_info
     caller_info = build_slack_caller_info(
         channel_id=channel,
         user_id=user_id,
         thread_ts=session_thread_ts,
+        display_name=user_info.get("display_name") or None,
+        avatar_url=user_info.get("avatar_url") or None,
+        email=user_info.get("email") or None,
     )
 
     # Claude 실행 (placeholder → 콜백 빌드 → executor → cleanup)

--- a/src/seosoyoung/slackbot/handlers/message.py
+++ b/src/seosoyoung/slackbot/handlers/message.py
@@ -217,12 +217,17 @@ def process_thread_message(
             except Exception as e:
                 logger.warning(f"after_execute hook 실패 (무시): {e}")
 
-    # 슬랙 호출 맥락으로부터 caller_info 조립 (Phase 4)
+    # 슬랙 호출 맥락으로부터 caller_info 조립 (통합 스키마 v1)
+    # user_info는 위 get_user_role 1회 호출의 결과 — display_name·avatar_url·email을
+    # 함께 들고 있어 별도 users.info 재호출 없이 신원 필드 채움 (정본 하나 원칙).
     from seosoyoung.slackbot.soulstream.caller_info import build_slack_caller_info
     caller_info = build_slack_caller_info(
         channel_id=channel,
         user_id=user_id,
         thread_ts=thread_ts,
+        display_name=user_info.get("display_name") or None,
+        avatar_url=user_info.get("avatar_url") or None,
+        email=user_info.get("email") or None,
     )
 
     # Claude 실행 (placeholder → 콜백 빌드 → executor → cleanup)

--- a/src/seosoyoung/slackbot/soulstream/caller_info.py
+++ b/src/seosoyoung/slackbot/soulstream/caller_info.py
@@ -3,9 +3,15 @@
 슬랙 채널/유저/스레드 컨텍스트로부터 soul-server /execute 요청에 실릴
 caller_info 딕셔너리를 조립합니다.
 
-스키마는 soul-server 쪽 Task.caller_info 컬럼과 호환됩니다 (Phase 1).
+스키마는 soul-server 쪽 Task.caller_info 컬럼과 호환됩니다 (통합 v1 스키마).
 soul-server /execute가 request body에 caller_info가 있으면 HTTP Request에서
-수집하지 않고 이 값을 그대로 사용합니다 (Phase 2).
+수집하지 않고 이 값을 그대로 사용합니다.
+
+통합 스키마 v1 (분석 캐시 §2):
+- top-level: source, user_id, [display_name, avatar_url, email], slack, bot_name
+- slack sub-dict: channel_id, user_id, [thread_ts]
+- top-level user_id ↔ slack.user_id는 동일값 의도적 중복 (push notifier·표시 호환)
+- 신원 필드(display_name 등)는 비면 키 자체가 들어가지 않음 (graceful)
 """
 
 from typing import Optional
@@ -18,6 +24,10 @@ def build_slack_caller_info(
     channel_id: str,
     user_id: str,
     thread_ts: Optional[str] = None,
+    *,
+    display_name: Optional[str] = None,
+    avatar_url: Optional[str] = None,
+    email: Optional[str] = None,
 ) -> dict:
     """슬랙 호출 맥락으로부터 caller_info 딕셔너리를 조립합니다.
 
@@ -25,15 +35,22 @@ def build_slack_caller_info(
         channel_id: 슬랙 채널 ID
         user_id: 호출한 슬랙 사용자 ID
         thread_ts: 스레드 타임스탬프 (없으면 None)
+        display_name: 발신자 표시명 (profile.display_name → real_name 폴백 후 호출자가 채움)
+        avatar_url: 발신자 프로필 이미지 URL (profile.image_192 권장)
+        email: 발신자 이메일 (profile.email)
 
     Returns:
         soul-server /execute 요청의 caller_info 필드에 실릴 딕셔너리.
         {
             "source": "slack",
+            "user_id": "U...",                        # top-level (의도적 중복)
+            "display_name": "서소영",                 # 있을 때만
+            "avatar_url": "https://...",              # 있을 때만
+            "email": "...",                           # 있을 때만
             "slack": {
-                "channel_id": ...,
-                "user_id": ...,
-                "thread_ts": ...,  # None 이면 생략
+                "channel_id": "C...",
+                "user_id": "U...",                    # = top-level user_id
+                "thread_ts": "...",                   # None/빈 값이면 생략
             },
             "bot_name": "seosoyoung",
         }
@@ -45,8 +62,18 @@ def build_slack_caller_info(
     if thread_ts:
         slack["thread_ts"] = thread_ts
 
-    return {
+    info: dict = {
         "source": "slack",
+        "user_id": user_id,
         "slack": slack,
         "bot_name": BOT_NAME,
     }
+    # 신원 필드는 비면 키 자체를 넣지 않는다 (graceful — 부분 성공 케이스)
+    if display_name:
+        info["display_name"] = display_name
+    if avatar_url:
+        info["avatar_url"] = avatar_url
+    if email:
+        info["email"] = email
+
+    return info

--- a/tests/soulstream/test_caller_info.py
+++ b/tests/soulstream/test_caller_info.py
@@ -1,4 +1,4 @@
-"""caller_info 조립 헬퍼 테스트 (Phase 4)"""
+"""caller_info 조립 헬퍼 테스트 (Phase 4 + 통합 스키마 v1)"""
 
 from seosoyoung.slackbot.soulstream.caller_info import (
     BOT_NAME,
@@ -50,11 +50,148 @@ class TestBuildSlackCallerInfo:
         assert "thread_ts" not in info["slack"]
 
     def test_schema_shape_matches_soul_server_contract(self):
-        """전체 스키마 모양이 soul-server Task.caller_info와 호환된다."""
+        """전체 스키마 모양이 soul-server Task.caller_info v1과 호환된다.
+
+        v1 스키마 (분석 캐시 §2):
+        - top-level: source, user_id, slack, bot_name, [display_name, avatar_url, email]
+        - slack sub-dict: channel_id, user_id, [thread_ts]
+        - 신원 필드(display_name 등)는 인자가 비면 생략(graceful)
+        """
         info = build_slack_caller_info(
             channel_id="C08ABC123",
             user_id="U0A9ELR53R8",
             thread_ts="1234567890.123456",
         )
-        assert set(info.keys()) == {"source", "slack", "bot_name"}
+        # 신원 필드 미제공 시: top-level은 필수 4개만
+        assert set(info.keys()) == {"source", "user_id", "slack", "bot_name"}
         assert set(info["slack"].keys()) == {"channel_id", "user_id", "thread_ts"}
+
+    # === 통합 스키마 v1 신규 케이스 ===
+
+    def test_top_level_user_id_mirrors_slack_user_id(self):
+        """top-level user_id는 slack.user_id와 동일값(의도적 중복).
+
+        Push notifier 화이트리스트와 표시 코드가 양쪽 어디서 읽어도 같은 값.
+        한쪽만 채우면 안 된다.
+        """
+        info = build_slack_caller_info(
+            channel_id="C08ABC123",
+            user_id="U0A9ELR53R8",
+            thread_ts="1234567890.123456",
+        )
+        assert info["user_id"] == "U0A9ELR53R8"
+        assert info["slack"]["user_id"] == "U0A9ELR53R8"
+        assert info["user_id"] == info["slack"]["user_id"]
+
+    def test_display_name_avatar_url_present_when_provided(self):
+        """display_name·avatar_url·email이 키워드 인자로 주어지면 top-level에 채워진다."""
+        info = build_slack_caller_info(
+            channel_id="C08ABC123",
+            user_id="U0A9ELR53R8",
+            thread_ts="1234567890.123456",
+            display_name="서소영",
+            avatar_url="https://avatars.slack-edge.com/.../image_192.png",
+            email="seosoyoung@example.com",
+        )
+        assert info["display_name"] == "서소영"
+        assert info["avatar_url"] == "https://avatars.slack-edge.com/.../image_192.png"
+        assert info["email"] == "seosoyoung@example.com"
+
+    def test_display_name_omitted_when_empty_or_none(self):
+        """display_name이 빈 문자열·None이면 caller_info에 키 자체가 들어가지 않는다(graceful)."""
+        info_none = build_slack_caller_info(
+            channel_id="C08ABC123",
+            user_id="U0A9ELR53R8",
+            display_name=None,
+        )
+        info_empty = build_slack_caller_info(
+            channel_id="C08ABC123",
+            user_id="U0A9ELR53R8",
+            display_name="",
+        )
+        assert "display_name" not in info_none
+        assert "display_name" not in info_empty
+
+    def test_avatar_url_omitted_when_empty_or_none(self):
+        """avatar_url이 빈 문자열·None이면 caller_info에 키 자체가 들어가지 않는다(graceful)."""
+        info_none = build_slack_caller_info(
+            channel_id="C08ABC123",
+            user_id="U0A9ELR53R8",
+            avatar_url=None,
+        )
+        info_empty = build_slack_caller_info(
+            channel_id="C08ABC123",
+            user_id="U0A9ELR53R8",
+            avatar_url="",
+        )
+        assert "avatar_url" not in info_none
+        assert "avatar_url" not in info_empty
+
+    def test_email_omitted_when_not_provided(self):
+        """email이 키워드 인자로 주어지지 않거나 비면 caller_info에 키 자체가 들어가지 않는다."""
+        info_default = build_slack_caller_info(
+            channel_id="C08ABC123",
+            user_id="U0A9ELR53R8",
+        )
+        info_none = build_slack_caller_info(
+            channel_id="C08ABC123",
+            user_id="U0A9ELR53R8",
+            email=None,
+        )
+        info_empty = build_slack_caller_info(
+            channel_id="C08ABC123",
+            user_id="U0A9ELR53R8",
+            email="",
+        )
+        assert "email" not in info_default
+        assert "email" not in info_none
+        assert "email" not in info_empty
+
+    def test_partial_identity_only_display_name(self):
+        """display_name만 있고 avatar_url 없으면 display_name만 들어간다 (부분 성공)."""
+        info = build_slack_caller_info(
+            channel_id="C08ABC123",
+            user_id="U0A9ELR53R8",
+            display_name="서소영",
+            avatar_url="",
+        )
+        assert info["display_name"] == "서소영"
+        assert "avatar_url" not in info
+
+    def test_v1_schema_shape_with_full_identity(self):
+        """신원 필드 모두 채운 v1 스키마의 전체 키 셋."""
+        info = build_slack_caller_info(
+            channel_id="C08ABC123",
+            user_id="U0A9ELR53R8",
+            thread_ts="1234567890.123456",
+            display_name="서소영",
+            avatar_url="https://avatars.slack-edge.com/.../image_192.png",
+            email="seosoyoung@example.com",
+        )
+        assert set(info.keys()) == {
+            "source",
+            "user_id",
+            "slack",
+            "bot_name",
+            "display_name",
+            "avatar_url",
+            "email",
+        }
+        assert set(info["slack"].keys()) == {"channel_id", "user_id", "thread_ts"}
+
+    def test_backward_compat_existing_callers(self):
+        """신원 키워드 인자 없이 위치 인자만 호출하는 기존 호출자 코드 호환.
+
+        ⚪ 비기능 요구사항 #9: 기존 호출자 코드 변경 최소화.
+        """
+        # 기존 호출 시그니처 — channel_id, user_id, thread_ts만
+        info = build_slack_caller_info("C08ABC123", "U0A9ELR53R8", "1234.5678")
+        assert info["source"] == "slack"
+        assert info["user_id"] == "U0A9ELR53R8"
+        assert info["slack"]["channel_id"] == "C08ABC123"
+        assert info["slack"]["thread_ts"] == "1234.5678"
+        assert info["bot_name"] == BOT_NAME
+        # 신원 필드 부재
+        assert "display_name" not in info
+        assert "avatar_url" not in info
+        assert "email" not in info

--- a/tests/test_auth_role.py
+++ b/tests/test_auth_role.py
@@ -1,0 +1,195 @@
+"""slackbot/auth.py: get_user_role / check_permission 단위 테스트.
+
+caller_info 통합 스키마 v1을 위해 get_user_role이 profile.display_name·image_192·email·is_bot도
+반환하도록 확장됐는지 검증한다 (분석 캐시 §2, 정본 하나 원칙).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from seosoyoung.slackbot.auth import check_permission, get_user_role
+
+
+# === Config 모킹 ===
+
+@pytest.fixture(autouse=True)
+def patch_config():
+    """Config.auth.{allowed_users, admin_users, role_tools} 모킹."""
+    with patch("seosoyoung.slackbot.auth.Config") as mock_cfg:
+        mock_cfg.auth.allowed_users = {"alice", "bob"}
+        mock_cfg.auth.admin_users = {"alice"}
+        mock_cfg.auth.role_tools = {
+            "admin": ["tool_a"],
+            "viewer": ["tool_b"],
+        }
+        yield mock_cfg
+
+
+def _make_users_info_response(
+    *,
+    name: str = "alice",
+    display_name: str = "서소영",
+    real_name: str = "Seo Soyoung",
+    image_192: str = "https://avatars.slack-edge.com/ALICE/image_192.png",
+    email: str = "alice@example.com",
+    is_bot: bool = False,
+) -> dict:
+    """Slack users.info 응답 페이로드를 합성한다 (실제 API 응답 구조)."""
+    return {
+        "user": {
+            "id": "U_ALICE",
+            "name": name,
+            "is_bot": is_bot,
+            "profile": {
+                "display_name": display_name,
+                "real_name": real_name,
+                "image_72": image_192.replace("_192", "_72"),
+                "image_192": image_192,
+                "image_512": image_192.replace("_192", "_512"),
+                "email": email,
+            },
+        },
+    }
+
+
+class TestGetUserRoleIdentityFields:
+    """get_user_role이 caller_info v1을 위한 신원 필드를 반환한다."""
+
+    def test_returns_display_name_from_profile(self):
+        client = MagicMock()
+        client.users_info.return_value = _make_users_info_response(
+            display_name="서소영", real_name="Seo Soyoung",
+        )
+        info = get_user_role("U_ALICE", client)
+        assert info is not None
+        assert info["display_name"] == "서소영"
+
+    def test_falls_back_to_real_name_when_display_name_empty(self):
+        """profile.display_name이 비면 real_name으로 폴백."""
+        client = MagicMock()
+        client.users_info.return_value = _make_users_info_response(
+            display_name="", real_name="Seo Soyoung",
+        )
+        info = get_user_role("U_ALICE", client)
+        assert info["display_name"] == "Seo Soyoung"
+
+    def test_display_name_empty_when_both_missing(self):
+        """display_name과 real_name 둘 다 없으면 빈 문자열."""
+        client = MagicMock()
+        client.users_info.return_value = _make_users_info_response(
+            display_name="", real_name="",
+        )
+        info = get_user_role("U_ALICE", client)
+        assert info["display_name"] == ""
+
+    def test_returns_avatar_url_from_image_192(self):
+        client = MagicMock()
+        url = "https://avatars.slack-edge.com/ALICE/image_192.png"
+        client.users_info.return_value = _make_users_info_response(image_192=url)
+        info = get_user_role("U_ALICE", client)
+        assert info["avatar_url"] == url
+
+    def test_avatar_url_empty_when_image_192_missing(self):
+        """profile.image_192가 없으면 avatar_url은 빈 문자열 (caller_info에서 누락 처리됨)."""
+        client = MagicMock()
+        response = _make_users_info_response()
+        del response["user"]["profile"]["image_192"]
+        client.users_info.return_value = response
+        info = get_user_role("U_ALICE", client)
+        assert info["avatar_url"] == ""
+
+    def test_returns_email_from_profile(self):
+        client = MagicMock()
+        client.users_info.return_value = _make_users_info_response(email="alice@x.com")
+        info = get_user_role("U_ALICE", client)
+        assert info["email"] == "alice@x.com"
+
+    def test_email_empty_when_profile_lacks_email(self):
+        """profile.email 권한이 없거나 빈 경우 — caller_info에서 누락 처리."""
+        client = MagicMock()
+        response = _make_users_info_response()
+        del response["user"]["profile"]["email"]
+        client.users_info.return_value = response
+        info = get_user_role("U_ALICE", client)
+        assert info["email"] == ""
+
+    def test_returns_is_bot_flag(self):
+        client = MagicMock()
+        client.users_info.return_value = _make_users_info_response(is_bot=True)
+        info = get_user_role("U_ALICE", client)
+        assert info["is_bot"] is True
+
+    def test_is_bot_defaults_to_false(self):
+        client = MagicMock()
+        response = _make_users_info_response()
+        del response["user"]["is_bot"]
+        client.users_info.return_value = response
+        info = get_user_role("U_ALICE", client)
+        assert info["is_bot"] is False
+
+
+class TestGetUserRoleBackwardCompat:
+    """기존 키(user_id, username, role, allowed_tools) 호환 유지."""
+
+    def test_returns_existing_keys(self):
+        client = MagicMock()
+        client.users_info.return_value = _make_users_info_response(name="alice")
+        info = get_user_role("U_ALICE", client)
+        assert info["user_id"] == "U_ALICE"
+        assert info["username"] == "alice"
+        assert info["role"] == "admin"
+        assert info["allowed_tools"] == ["tool_a"]
+
+    def test_viewer_role_for_non_admin(self):
+        client = MagicMock()
+        client.users_info.return_value = _make_users_info_response(name="bob")
+        info = get_user_role("U_BOB", client)
+        assert info["role"] == "viewer"
+        assert info["allowed_tools"] == ["tool_b"]
+
+
+class TestGetUserRoleFailure:
+    """Slack API 실패 시 graceful — None 반환 (기존 동작 유지)."""
+
+    def test_returns_none_on_slack_api_error(self):
+        from slack_sdk.errors import SlackApiError
+        client = MagicMock()
+        client.users_info.side_effect = SlackApiError(
+            "rate limited", response={"error": "ratelimited"}
+        )
+        info = get_user_role("U_ALICE", client)
+        assert info is None
+
+    def test_returns_none_on_generic_exception(self):
+        client = MagicMock()
+        client.users_info.side_effect = RuntimeError("network down")
+        info = get_user_role("U_ALICE", client)
+        assert info is None
+
+    def test_returns_none_on_malformed_response(self):
+        """user 키 자체가 없는 응답 — graceful None."""
+        client = MagicMock()
+        client.users_info.return_value = {}
+        info = get_user_role("U_ALICE", client)
+        # user 없으면 KeyError → except → None
+        assert info is None
+
+
+class TestCheckPermissionUnchanged:
+    """check_permission은 본 카드 범위 외 — 기존 동작 유지 검증."""
+
+    def test_allowed_user(self):
+        client = MagicMock()
+        client.users_info.return_value = _make_users_info_response(name="alice")
+        assert check_permission("U_ALICE", client) is True
+
+    def test_disallowed_user(self):
+        client = MagicMock()
+        client.users_info.return_value = _make_users_info_response(name="charlie")
+        assert check_permission("U_CHARLIE", client) is False
+
+    def test_returns_false_on_exception(self):
+        client = MagicMock()
+        client.users_info.side_effect = RuntimeError("boom")
+        assert check_permission("U_ALICE", client) is False


### PR DESCRIPTION
## Summary
- 슬랙봇이 세션 생성 시 caller_info에 발신자 표시명·avatar URL·이메일 포함
- `auth.py:get_user_role`을 신원 정보까지 함께 추출하도록 확장 (`users.info` 1회 호출 정본화)
- 통합 caller_info 스키마 v1 (top-level: source, display_name, user_id, avatar_url, email)

## Context
caller_info 정체성 확장 통합 작업의 슬랙봇 부분. 통합 작업 다른 plan:
- Plan B (soulstream): https://github.com/eiaserinnys/soulstream/tree/feature/caller-info-multi-source
- Plan C (soul-app RN): https://github.com/eiaserinnys/soulstream-dashboard-ios/tree/feature/caller-info-soul-app

분석 캐시·통합 스키마 v1 정본은 본체 `.local/artifacts/analysis/20260507-1135-caller-info-identity-schema.md`.

## 변경 통계
6 파일, +408/-15 (코드 +85 / 호출부 +14 / 테스트 +338)

## Test plan
- [x] 본 카드 영역 단위 테스트 77/77 통과
- [x] push notifier 화이트리스트 회귀 없음 (source='slack' 유지)
- [x] users.info rate limit·실패 graceful 처리
- [x] code-reviewer P0/P1 없음
- [ ] (사용자) Plan B Phase 4 머지 후 실제 슬랙 멘션 시 웹 대시보드 표시 검증

pre-existing 10개 실패는 main에서도 동일하게 존재 (직접 검증).

🤖 Generated with [Claude Code](https://claude.com/claude-code)