### PR TITLE
fix(slackbot): 2차+ 메시지 intervene에 caller_info 첨부 (F-9)

### DIFF
--- a/src/seosoyoung/slackbot/soulstream/executor.py
+++ b/src/seosoyoung/slackbot/soulstream/executor.py
@@ -187,6 +187,8 @@ class ClaudeExecutor:
         if not lock.acquire(blocking=False):
             # 인터벤션: pending에 저장 후 interrupt
             # 인터벤션은 기존 세션 복구이므로 profile은 초기 세션 생성 시점에만 필요
+            # F-9 fix(2026-05-08): caller_info를 _handle_intervention까지 운반하여
+            # 슬랙 2차+ 메시지가 InterventionSentEvent.caller_info로 wire되도록 한다.
             self._handle_intervention(
                 thread_ts, prompt, msg_ts,
                 on_compact=on_compact,
@@ -204,6 +206,7 @@ class ClaudeExecutor:
                 on_input_request=on_input_request,
                 on_input_request_responded=on_input_request_responded,
                 on_input_request_expired=on_input_request_expired,
+                caller_info=caller_info,
             )
             return
 
@@ -259,6 +262,7 @@ class ClaudeExecutor:
         on_input_request=None,
         on_input_request_responded=None,
         on_input_request_expired=None,
+        caller_info: Optional[dict] = None,
     ):
         """인터벤션 처리: 실행 중인 스레드에 새 메시지가 도착한 경우
 
@@ -270,6 +274,9 @@ class ClaudeExecutor:
         처리되는데, 이 큐가 context를 함께 저장하는 메커니즘이 없다.
         따라서 인터벤션이 flush되어 실행될 때 context 없이 프롬프트만 전달된다.
         이 제한은 인터벤션 기능 전체의 리팩터링 시 별도로 해결한다.
+
+        F-9 fix(2026-05-08): caller_info를 fire_interrupt_remote에 forward하여
+        2차+ 메시지의 발신자 신원이 InterventionSentEvent.caller_info까지 운반되도록 한다.
         """
         logger.info(f"인터벤션 발생: thread={thread_ts}")
 
@@ -279,6 +286,7 @@ class ClaudeExecutor:
             session_id=self.get_session_id(thread_ts),
             pending_session_interventions=self._pending_session_interventions,
             pending_session_lock=self._pending_session_lock,
+            caller_info=caller_info,
         )
 
     def _run_with_lock(
@@ -460,13 +468,22 @@ class ClaudeExecutor:
 
         if pending:
             adapter = self._get_service_adapter()
-            for (pending_prompt, pending_user) in pending:
+            # F-9 fix(2026-05-08): tuple 형식이 (prompt, user)에서 (prompt, user, caller_info)로
+            # 확장됐다 (intervention.py:fire_interrupt_remote가 caller_info도 저장).
+            # 구버전 2-tuple(메모리에 남아있던 데이터 등)도 graceful 처리.
+            for entry in pending:
+                if len(entry) == 3:
+                    pending_prompt, pending_user, pending_caller_info = entry
+                else:
+                    pending_prompt, pending_user = entry
+                    pending_caller_info = None
                 try:
                     from seosoyoung.utils.async_bridge import run_in_new_loop as _run
                     _run(adapter.intervene(
                         agent_session_id=session_id,
                         text=pending_prompt,
                         user=pending_user,
+                        caller_info=pending_caller_info,
                     ))
                     logger.info(f"[Remote] 버퍼된 인터벤션 flush: thread={thread_ts}, session={session_id}")
                 except Exception as e:

--- a/src/seosoyoung/slackbot/soulstream/intervention.py
+++ b/src/seosoyoung/slackbot/soulstream/intervention.py
@@ -28,6 +28,7 @@ class InterventionManager:
         session_id: Optional[str] = None,
         pending_session_interventions: Optional[dict] = None,
         pending_session_lock: Optional[Any] = None,
+        caller_info: Optional[dict] = None,
     ):
         """Soulstream에 HTTP intervene 요청 (agent_session_id 기반)
 
@@ -36,6 +37,11 @@ class InterventionManager:
 
         sync 스레드 컨텍스트에서 호출되므로
         run_in_new_loop로 격리된 이벤트 루프를 생성해 async 호출을 수행합니다.
+
+        F-9 fix(2026-05-08): caller_info를 service_adapter.intervene에 forward하고,
+        버퍼 보관 시에도 함께 저장하여 session_id 확보 후 flush될 때 운반되도록 한다.
+        이로 인해 슬랙 2차+ 메시지가 InterventionSentEvent.caller_info를 wire에 박아
+        unified-dashboard·soul-app에서 발신자(슬랙)의 아바타·이름이 표시된다.
         """
         from seosoyoung.utils.async_bridge import run_in_new_loop
 
@@ -47,6 +53,7 @@ class InterventionManager:
                         agent_session_id=session_id,
                         text=prompt,
                         user="intervention",
+                        caller_info=caller_info,
                     )
                 )
                 logger.info(f"[Remote] 인터벤션 전송 완료: thread={thread_ts}, session={session_id}")
@@ -55,12 +62,14 @@ class InterventionManager:
                 logger.warning(f"[Remote] 인터벤션 전송 실패: thread={thread_ts}, {e}")
                 return
 
-        # 2. session_id 미확보 → 버퍼에 보관
+        # 2. session_id 미확보 → 버퍼에 보관 (caller_info도 함께)
         if pending_session_interventions is not None and pending_session_lock is not None:
             with pending_session_lock:
                 if thread_ts not in pending_session_interventions:
                     pending_session_interventions[thread_ts] = []
-                pending_session_interventions[thread_ts].append((prompt, "intervention"))
+                pending_session_interventions[thread_ts].append(
+                    (prompt, "intervention", caller_info)
+                )
             logger.info(f"[Remote] 인터벤션 버퍼에 보관 (session_id 미확보): thread={thread_ts}")
             return
 

--- a/src/seosoyoung/slackbot/soulstream/service_adapter.py
+++ b/src/seosoyoung/slackbot/soulstream/service_adapter.py
@@ -177,8 +177,12 @@ class ClaudeServiceAdapter:
         user: str,
         *,
         attachment_paths: Optional[List[str]] = None,
+        caller_info: Optional[dict] = None,
     ) -> bool:
         """세션에 인터벤션 전송 (agent_session_id 기반)
+
+        F-9 fix(2026-05-08): caller_info를 service_client.intervene에 forward하여
+        InterventionSentEvent.caller_info까지 운반한다.
 
         Returns:
             True: 성공, False: 실패
@@ -189,6 +193,7 @@ class ClaudeServiceAdapter:
                 text=text,
                 user=user,
                 attachment_paths=attachment_paths,
+                caller_info=caller_info,
             )
             logger.info(f"[Remote] 인터벤션 전송 완료: session={agent_session_id}")
             return True

--- a/src/seosoyoung/slackbot/soulstream/service_client.py
+++ b/src/seosoyoung/slackbot/soulstream/service_client.py
@@ -525,12 +525,17 @@ class SoulServiceClient:
         user: str,
         *,
         attachment_paths: Optional[List[str]] = None,
+        caller_info: Optional[dict] = None,
     ) -> dict:
         """세션에 개입 메시지 전송
 
         POST /sessions/{agent_session_id}/intervene
         - 실행 중이면 intervention queue에 추가
         - 완료된 세션이면 자동 resume
+
+        F-9 fix(2026-05-08): caller_info를 body에 첨부하여 InterveneRequest.caller_info로
+        운반한다. 서버 task_manager가 이를 큐 message에 담아 InterventionSentEvent.caller_info로
+        emit하므로, 슬랙 2차+ 메시지가 unified-dashboard·soul-app에서 발신자 아바타로 표시된다.
         """
         session = await self._get_session()
         url = f"{self.base_url}/sessions/{agent_session_id}/intervene"
@@ -538,6 +543,8 @@ class SoulServiceClient:
         data = {"text": text, "user": user}
         if attachment_paths:
             data["attachment_paths"] = attachment_paths
+        if caller_info:
+            data["caller_info"] = caller_info
 
         async with session.post(url, json=data) as response:
             if response.status == 202:

--- a/tests/soulstream/test_service_adapter.py
+++ b/tests/soulstream/test_service_adapter.py
@@ -271,11 +271,38 @@ class TestIntervene:
             user="user1",
         )
         assert result is True
+        # F-9 fix(2026-05-08): caller_info=None이 명시적으로 forward됨 (graceful default).
         mock_client.intervene.assert_awaited_once_with(
             agent_session_id="sess-abc",
             text="추가 지시",
             user="user1",
             attachment_paths=None,
+            caller_info=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_intervene_with_caller_info(self, adapter, mock_client):
+        """F-9 fix(2026-05-08): caller_info가 service_client.intervene까지 forward."""
+        mock_client.intervene.return_value = {"queued": True}
+        ci = {
+            "source": "slack",
+            "display_name": "동료",
+            "avatar_url": "https://slack/img.png",
+            "user_id": "U123",
+        }
+        result = await adapter.intervene(
+            agent_session_id="sess-abc",
+            text="추가 지시",
+            user="U123",
+            caller_info=ci,
+        )
+        assert result is True
+        mock_client.intervene.assert_awaited_once_with(
+            agent_session_id="sess-abc",
+            text="추가 지시",
+            user="U123",
+            attachment_paths=None,
+            caller_info=ci,
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

F-9 fix(2026-05-08, atom `beed44e0`): 슬랙 2차+ 메시지가 `unified-dashboard`에서 dashboard owner의 Google 프로필로 표시되던 결함의 슬랙봇 측 fix.

원인: `service_client.intervene`가 `caller_info`를 body에 박지 않아 soulstream 서버가 `InterventionSentEvent.caller_info`로 운반하지 못함.

서버측 fix는 별 PR — soulstream 리포 #17.

## 변경

- `service_client.intervene`: `caller_info` 인자 + body에 첨부
- `service_adapter.intervene`: forward
- `intervention.fire_interrupt_remote`: `caller_info` 받아 service_adapter에 forward + buffer tuple 형식 (prompt, user, caller_info)로 확장 (graceful 2-tuple 호환)
- `executor._handle_intervention`: caller_info 인자 추가 → fire_interrupt_remote 전달
- `executor._register_session_id` buffer flush: 3-tuple 처리 + caller_info 운반

mention/message handler는 이미 `build_slack_caller_info` 결과를 `run_claude_in_session(caller_info=...)`에 전달하고 있어 추가 변경 불필요.

## 페어 PR

서버측 변경: https://github.com/eiaserinnys/soulstream/pull/17

## Test plan

- [x] `tests/soulstream`: 259 passed
- [x] 신규 회귀 테스트 1 케이스 (test_intervene_with_caller_info)
- [x] 기존 테스트 갱신 1 케이스 (caller_info=None 명시)
- [ ] (사용자) 머지 후 라이브 검증 — 슬랙에서 2차+ 메시지를 보냈을 때 unified-dashboard가 슬랙 발신자 아바타·이름을 표시

## 분석 캐시

`roselin/.local/artifacts/analysis/20260508-1112-f9-2nd-msg-caller-info.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)