### PR TITLE
refactor(slackbot): parent_event_id 의존 폐기 — 단일 활성 슬롯 모델

### DIFF
--- a/src/seosoyoung/slackbot/presentation/node_map.py
+++ b/src/seosoyoung/slackbot/presentation/node_map.py
@@ -14,7 +14,6 @@ class SlackNode:
     event_id: int
     node_type: str           # "thinking" | "tool" | "text"
     msg_ts: str              # 슬랙 메시지 timestamp
-    parent_event_id: Optional[int] = None
     tool_use_id: Optional[str] = None
     tool_name: Optional[str] = None
     completed: bool = False
@@ -37,27 +36,28 @@ class SlackNodeMap:
     대시보드의 ProcessingContext를 슬랙에 맞게 번안.
     - _nodes: event_id -> SlackNode
     - _tool_use_index: tool_use_id -> event_id (tool_result 매칭용)
-    - _last_text_by_parent: parent_event_id -> event_id (text_delta/text_end가 찾을 대상)
+    - _active_text_event_id: text_start ~ text_end 사이의 활성 text 노드 단일 슬롯.
+      한 시점에 활성 text 블록은 1개라는 invariant에 기반 (Anthropic Messages API
+      스트리밍에서 text 블록은 시리얼). 이전 모델(`_last_text_by_parent` dict)이
+      `parent_event_id` 키에 의존했던 것을, wire 평탄화 후에도 동작하도록 단순화.
     """
 
     def __init__(self):
         self._nodes: dict[int, SlackNode] = {}
         self._tool_use_index: dict[str, int] = {}
-        self._last_text_by_parent: dict[Optional[int], int] = {}
+        self._active_text_event_id: Optional[int] = None
         self._input_requests: dict[str, InputRequestNode] = {}  # request_id -> InputRequestNode
 
     def add_thinking(
         self,
         event_id: int,
         msg_ts: str,
-        parent_event_id: Optional[int] = None,
     ) -> SlackNode:
         """thinking 이벤트에 대응하는 노드 등록"""
         node = SlackNode(
             event_id=event_id,
             node_type="thinking",
             msg_ts=msg_ts,
-            parent_event_id=parent_event_id,
         )
         self._nodes[event_id] = node
         return node
@@ -66,21 +66,19 @@ class SlackNodeMap:
         self,
         event_id: int,
         msg_ts: str,
-        parent_event_id: Optional[int] = None,
     ) -> SlackNode:
-        """text 노드 등록
+        """text 노드 등록.
 
-        _last_text_by_parent에 등록하여 find_text_node가
-        text_delta/text_end에서 대상 노드를 찾도록 한다.
+        활성 슬롯을 새 event_id로 갱신. 이전 활성 노드가 있으면 슬롯에서 *덮어쓴다*
+        (text_end 누락 fail-safe — 이전 dict 모델에서 같은 키로 덮어쓰던 동작과 등가).
         """
         node = SlackNode(
             event_id=event_id,
             node_type="text",
             msg_ts=msg_ts,
-            parent_event_id=parent_event_id,
         )
         self._nodes[event_id] = node
-        self._last_text_by_parent[parent_event_id] = event_id
+        self._active_text_event_id = event_id
         return node
 
     def add_tool(
@@ -88,7 +86,6 @@ class SlackNodeMap:
         event_id: int,
         msg_ts: str,
         tool_use_id: str,
-        parent_event_id: Optional[int] = None,
         tool_name: Optional[str] = None,
     ) -> SlackNode:
         """tool_start 이벤트에 대응하는 노드 등록"""
@@ -96,7 +93,6 @@ class SlackNodeMap:
             event_id=event_id,
             node_type="tool",
             msg_ts=msg_ts,
-            parent_event_id=parent_event_id,
             tool_use_id=tool_use_id,
             tool_name=tool_name,
         )
@@ -105,18 +101,15 @@ class SlackNodeMap:
             self._tool_use_index[tool_use_id] = event_id
         return node
 
-    def find_text_node(
-        self,
-        parent_event_id: Optional[int],
-    ) -> Optional[SlackNode]:
-        """parent_event_id에 대응하는 text 노드 검색
+    def find_text_node(self) -> Optional[SlackNode]:
+        """현재 활성 text 노드 반환 (없으면 None).
 
-        text_start에서 등록한 text 노드를 text_delta/text_end에서 찾는다.
+        text_start에서 등록한 text 노드를 text_delta/text_end가 찾는다.
+        text_end 처리 후 슬롯이 비워지므로 text 블록의 lifecycle을 정확히 따른다.
         """
-        event_id = self._last_text_by_parent.get(parent_event_id)
-        if event_id is None:
+        if self._active_text_event_id is None:
             return None
-        return self._nodes.get(event_id)
+        return self._nodes.get(self._active_text_event_id)
 
     def find_tool_by_use_id(
         self,
@@ -129,10 +122,15 @@ class SlackNodeMap:
         return self._nodes.get(event_id)
 
     def _remove_from_indexes(self, node: SlackNode) -> None:
-        """완료된 노드를 룩업 인덱스에서 제거 (노드 자체는 _nodes에 유지)"""
-        parent = node.parent_event_id
-        if self._last_text_by_parent.get(parent) == node.event_id:
-            del self._last_text_by_parent[parent]
+        """완료된 노드를 룩업 인덱스에서 제거 (노드 자체는 _nodes에 유지).
+
+        node_type == "text" 가드: 활성 텍스트 슬롯은 *text 노드만* 사용한다.
+        thinking/tool 노드의 event_id가 우연히 활성 슬롯 값과 같더라도(운영 환경에서
+        event_id는 SSE 스트림 내 단조증가라 충돌 0%이지만), invariant를 코드로 명시하여
+        후임이 추측하지 않도록 한다.
+        """
+        if node.node_type == "text" and self._active_text_event_id == node.event_id:
+            self._active_text_event_id = None
         if node.tool_use_id:
             self._tool_use_index.pop(node.tool_use_id, None)
 

--- a/src/seosoyoung/slackbot/presentation/progress.py
+++ b/src/seosoyoung/slackbot/presentation/progress.py
@@ -150,7 +150,7 @@ def build_event_callbacks(
         except Exception as e:
             logger.debug(f"thinking 메시지 삭제 실패 (무시): ts={msg_ts}, err={e}")
 
-    async def on_thinking(thinking_text: str, event_id, parent_event_id):
+    async def on_thinking(thinking_text: str, event_id):
         try:
             if mode == "clean" and _board[0] is not None:
                 item_id = f"thinking_{event_id}"
@@ -167,7 +167,7 @@ def build_event_callbacks(
                     text=text,
                 )
                 msg_ts = reply["ts"]
-                node = node_map.add_thinking(event_id, msg_ts, parent_event_id)
+                node = node_map.add_thinking(event_id, msg_ts)
                 if thinking_text:
                     node.text_buffer = thinking_text
                 # [clean 모드만] 설정된 시간 후 자동 삭제
@@ -176,7 +176,7 @@ def build_event_callbacks(
         except Exception as e:
             logger.warning(f"thinking 메시지 생성 실패: {e}")
 
-    async def on_text_start(event_id, parent_event_id):
+    async def on_text_start(event_id):
         try:
             if mode == "clean":
                 # clean 모드: placeholder를 재사용하여 텍스트 누적 시작
@@ -190,11 +190,11 @@ def build_event_callbacks(
                     text=text,
                 )
                 msg_ts = reply["ts"]
-                node_map.add_text(event_id, msg_ts, parent_event_id)
+                node_map.add_text(event_id, msg_ts)
         except Exception as e:
             logger.warning(f"text_start 처리 실패: {e}")
 
-    async def on_text_delta(text: str, event_id, parent_event_id):
+    async def on_text_delta(text: str, event_id):
         try:
             if mode == "clean":
                 # clean 모드: placeholder에 누적 텍스트 갱신
@@ -204,10 +204,10 @@ def build_event_callbacks(
                     display_text = format_thinking_text(_text_buffer[0])
                     update_message(pctx.client, pctx.channel, ts, display_text)
             else:
-                # full dump 모드: text 노드 찾아서 갱신
-                node = node_map.find_text_node(parent_event_id)
+                # full dump 모드: 활성 text 노드를 찾아서 갱신
+                node = node_map.find_text_node()
                 if not node:
-                    logger.debug(f"text_delta: text 노드 없음 (parent_event_id={parent_event_id})")
+                    logger.debug(f"text_delta: 활성 text 노드 없음 (event_id={event_id})")
                     return
                 node.text_buffer += text
                 display_text = format_thinking_text(node.text_buffer)
@@ -215,7 +215,7 @@ def build_event_callbacks(
         except Exception as e:
             logger.warning(f"text_delta 갱신 실패: {e}")
 
-    async def on_text_end(event_id, parent_event_id):
+    async def on_text_end(event_id):
         try:
             if mode == "clean":
                 # clean 모드: placeholder의 텍스트를 완료 상태로 갱신
@@ -227,10 +227,10 @@ def build_event_callbacks(
                     except Exception as e:
                         logger.warning(f"text_end 갱신 실패: {e}")
             else:
-                # full dump 모드: text 노드를 완료 처리
-                node = node_map.find_text_node(parent_event_id)
+                # full dump 모드: 활성 text 노드를 완료 처리
+                node = node_map.find_text_node()
                 if not node:
-                    logger.debug(f"text_end: text 노드 없음 (event_id={event_id}, parent_event_id={parent_event_id})")
+                    logger.debug(f"text_end: 활성 text 노드 없음 (event_id={event_id})")
                     return
                 # SSE 재연결 시 이미 처리한 이벤트가 재생될 수 있음 — 중복 방지
                 if node.completed:
@@ -247,13 +247,13 @@ def build_event_callbacks(
         except Exception as e:
             logger.warning(f"text_end 처리 실패: {e}")
 
-    async def on_tool_start(tool_name: str, tool_input, tool_use_id: str, event_id, parent_event_id):
+    async def on_tool_start(tool_name: str, tool_input, tool_use_id: str, event_id):
         try:
             if mode == "clean" and _board[0] is not None:
                 item_id = f"tool_{event_id}"
                 content = format_tool_initial(tool_name, tool_input)
                 _board[0].add(item_id, content)
-                node_map.add_tool(event_id, "", tool_use_id, parent_event_id, tool_name)
+                node_map.add_tool(event_id, "", tool_use_id, tool_name=tool_name)
             else:
                 # keep 모드 또는 board 생성 실패 시: 기존 로직 그대로
                 text = format_tool_initial(tool_name, tool_input)
@@ -263,11 +263,11 @@ def build_event_callbacks(
                     text=text,
                 )
                 msg_ts = reply["ts"]
-                node_map.add_tool(event_id, msg_ts, tool_use_id, parent_event_id, tool_name)
+                node_map.add_tool(event_id, msg_ts, tool_use_id, tool_name=tool_name)
         except Exception as e:
             logger.warning(f"tool_start 메시지 생성 실패: {e}")
 
-    async def on_tool_result(result, tool_use_id: str, is_error, event_id, parent_event_id):
+    async def on_tool_result(result, tool_use_id: str, is_error, event_id):
         try:
             node = node_map.find_tool_by_use_id(tool_use_id)
             if not node:

--- a/src/seosoyoung/slackbot/soulstream/service_client.py
+++ b/src/seosoyoung/slackbot/soulstream/service_client.py
@@ -738,13 +738,14 @@ class SoulServiceClient:
         on_debug: Optional[Callable[[str], Awaitable[None]]] = None,
         on_session: Optional[Callable[[str], Awaitable[None]]] = None,
         on_credential_alert: Optional[Callable[[dict], Awaitable[None]]] = None,
-        # 세분화 이벤트 콜백
-        on_thinking: Optional[Callable] = None,       # (thinking_text, event_id, parent_event_id) -> None
-        on_text_start: Optional[Callable] = None,     # (event_id, parent_event_id) -> None
-        on_text_delta: Optional[Callable] = None,     # (text, event_id, parent_event_id) -> None
-        on_text_end: Optional[Callable] = None,       # (event_id, parent_event_id) -> None
-        on_tool_start: Optional[Callable] = None,     # (tool_name, tool_input, tool_use_id, event_id, parent_event_id) -> None
-        on_tool_result: Optional[Callable] = None,    # (result, tool_use_id, is_error, event_id, parent_event_id) -> None
+        # 세분화 이벤트 콜백 — wire payload의 parent_event_id 필드는 무시한다
+        # (단일 활성 슬롯 모델, presentation/node_map.py 참조)
+        on_thinking: Optional[Callable] = None,       # (thinking_text, event_id) -> None
+        on_text_start: Optional[Callable] = None,     # (event_id) -> None
+        on_text_delta: Optional[Callable] = None,     # (text, event_id) -> None
+        on_text_end: Optional[Callable] = None,       # (event_id) -> None
+        on_tool_start: Optional[Callable] = None,     # (tool_name, tool_input, tool_use_id, event_id) -> None
+        on_tool_result: Optional[Callable] = None,    # (result, tool_use_id, is_error, event_id) -> None
         on_input_request: Optional[Callable] = None,  # (request_id, questions, agent_session_id) -> None
         on_input_request_responded: Optional[Callable] = None,  # (request_id) -> None
         on_input_request_expired: Optional[Callable] = None,    # (request_id) -> None
@@ -805,16 +806,12 @@ class SoulServiceClient:
                         await on_thinking(
                             event.data.get("thinking", ""),
                             eid,
-                            event.data.get("parent_event_id"),
                         )
 
                 elif event.event == "text_start":
                     if on_text_start:
                         eid = int(event.id) if event.id is not None else None
-                        await on_text_start(
-                            eid,
-                            event.data.get("parent_event_id"),
-                        )
+                        await on_text_start(eid)
 
                 elif event.event == "text_delta":
                     if on_text_delta:
@@ -822,16 +819,12 @@ class SoulServiceClient:
                         await on_text_delta(
                             event.data.get("text", ""),
                             eid,
-                            event.data.get("parent_event_id"),
                         )
 
                 elif event.event == "text_end":
                     if on_text_end:
                         eid = int(event.id) if event.id is not None else None
-                        await on_text_end(
-                            eid,
-                            event.data.get("parent_event_id"),
-                        )
+                        await on_text_end(eid)
 
                 elif event.event == "tool_start":
                     if on_tool_start:
@@ -841,7 +834,6 @@ class SoulServiceClient:
                             event.data.get("tool_input", {}),
                             event.data.get("tool_use_id", ""),
                             eid,
-                            event.data.get("parent_event_id"),
                         )
 
                 elif event.event == "tool_result":
@@ -852,7 +844,6 @@ class SoulServiceClient:
                             event.data.get("tool_use_id", ""),
                             event.data.get("is_error", False),
                             eid,
-                            event.data.get("parent_event_id"),
                         )
 
                 elif event.event == "input_request":

--- a/tests/presentation/test_node_map.py
+++ b/tests/presentation/test_node_map.py
@@ -11,40 +11,42 @@ from seosoyoung.slackbot.presentation.node_map import (
 class TestSlackNodeMap:
     def test_add_thinking(self):
         nm = SlackNodeMap()
-        node = nm.add_thinking(event_id=1, msg_ts="1234.5678", parent_event_id=None)
+        node = nm.add_thinking(event_id=1, msg_ts="1234.5678")
         assert node.event_id == 1
         assert node.node_type == "thinking"
         assert node.msg_ts == "1234.5678"
 
     def test_add_tool(self):
         nm = SlackNodeMap()
-        node = nm.add_tool(event_id=2, msg_ts="1234.5679", tool_use_id="tu_123", parent_event_id=1, tool_name="Bash")
+        node = nm.add_tool(event_id=2, msg_ts="1234.5679", tool_use_id="tu_123", tool_name="Bash")
         assert node.event_id == 2
         assert node.tool_use_id == "tu_123"
         assert node.tool_name == "Bash"
 
     def test_find_text_node(self):
+        """add_text 후 활성 슬롯에서 노드를 찾는다"""
         nm = SlackNodeMap()
-        nm.add_text(event_id=1, msg_ts="ts1", parent_event_id=100)
-        node = nm.find_text_node(parent_event_id=100)
+        nm.add_text(event_id=1, msg_ts="ts1")
+        node = nm.find_text_node()
         assert node is not None
         assert node.event_id == 1
 
     def test_find_text_node_not_found(self):
+        """활성 슬롯이 비어 있으면 None 반환"""
         nm = SlackNodeMap()
-        node = nm.find_text_node(parent_event_id=999)
+        node = nm.find_text_node()
         assert node is None
 
     def test_thinking_not_in_text_index(self):
-        """Phase 3: add_thinking은 _last_text_by_parent에 등록하지 않는다"""
+        """add_thinking은 활성 텍스트 슬롯을 채우지 않는다"""
         nm = SlackNodeMap()
-        nm.add_thinking(event_id=1, msg_ts="ts1", parent_event_id=100)
-        node = nm.find_text_node(parent_event_id=100)
+        nm.add_thinking(event_id=1, msg_ts="ts1")
+        node = nm.find_text_node()
         assert node is None
 
     def test_find_tool_by_use_id(self):
         nm = SlackNodeMap()
-        nm.add_tool(event_id=3, msg_ts="ts3", tool_use_id="tu_456", parent_event_id=1)
+        nm.add_tool(event_id=3, msg_ts="ts3", tool_use_id="tu_456")
         node = nm.find_tool_by_use_id("tu_456")
         assert node is not None
         assert node.event_id == 3
@@ -67,10 +69,10 @@ class TestSlackNodeMap:
         assert node is None
 
     def test_add_text_independent(self):
-        """독립 text 노드가 _last_text_by_parent에 등록되는지 (S6)"""
+        """독립 text 노드가 활성 슬롯에 등록되는지"""
         nm = SlackNodeMap()
-        nm.add_text(event_id=10, msg_ts="ts10", parent_event_id=5)
-        node = nm.find_text_node(parent_event_id=5)
+        nm.add_text(event_id=10, msg_ts="ts10")
+        node = nm.find_text_node()
         assert node is not None
         assert node.event_id == 10
         assert node.node_type == "text"
@@ -87,12 +89,12 @@ class TestSlackNodeMap:
     def test_clear_completed(self):
         """완료된 노드 정리 (C1 수정)"""
         nm = SlackNodeMap()
-        nm.add_text(event_id=1, msg_ts="ts1", parent_event_id=100)
-        nm.add_tool(event_id=2, msg_ts="ts2", tool_use_id="tu_1", parent_event_id=100)
+        nm.add_text(event_id=1, msg_ts="ts1")
+        nm.add_tool(event_id=2, msg_ts="ts2", tool_use_id="tu_1")
         nm.mark_completed(1)
         count = nm.clear_completed()
         assert count == 1
-        assert nm.find_text_node(parent_event_id=100) is None
+        assert nm.find_text_node() is None
         # tool은 아직 있어야 함
         assert nm.find_tool_by_use_id("tu_1") is not None
 
@@ -103,6 +105,68 @@ class TestSlackNodeMap:
         count = nm.clear_completed()
         assert count == 1
         assert nm.find_tool_by_use_id("tu_2") is None
+
+    # --- 단일 활성 슬롯 모델 신규 케이스 ---
+
+    def test_add_text_overwrites_active_slot(self):
+        """새 add_text가 활성 슬롯을 덮어쓴다 (text_end 누락 fail-safe)"""
+        nm = SlackNodeMap()
+        nm.add_text(event_id=1, msg_ts="ts1")
+        nm.add_text(event_id=2, msg_ts="ts2")
+        node = nm.find_text_node()
+        assert node is not None and node.event_id == 2
+
+    def test_text_end_releases_active_slot(self):
+        """mark_completed_and_remove가 활성 슬롯을 비운다"""
+        nm = SlackNodeMap()
+        nm.add_text(event_id=1, msg_ts="ts1")
+        nm.mark_completed_and_remove(1)
+        assert nm.find_text_node() is None
+
+    def test_active_text_slot_isolation_per_instance(self):
+        """🔵 #9 — 두 SlackNodeMap 인스턴스의 활성 슬롯이 격리됨"""
+        nm_a = SlackNodeMap()
+        nm_b = SlackNodeMap()
+        nm_a.add_text(event_id=1, msg_ts="ts_a")
+        nm_b.add_text(event_id=99, msg_ts="ts_b")
+        assert nm_a.find_text_node().event_id == 1
+        assert nm_b.find_text_node().event_id == 99
+
+    def test_clear_completed_thinking_does_not_clear_active_text_slot(self):
+        """node_type 가드 검증 — thinking 노드 정리가 활성 텍스트 슬롯을 건드리지 않는다.
+
+        실제 운영에서는 SSE 스트림의 event_id가 단조증가라 충돌이 일어나지 않지만,
+        invariant를 코드로 명시하기 위해 추가한 가드를 보호한다 (P1 #3).
+        """
+        nm = SlackNodeMap()
+        nm.add_text(event_id=5, msg_ts="ts_text")
+        # thinking 노드를 별도 event_id에 추가
+        nm.add_thinking(event_id=99, msg_ts="ts_thinking")
+        nm.mark_completed(99)
+        nm.clear_completed()
+        # 활성 텍스트 슬롯은 그대로
+        node = nm.find_text_node()
+        assert node is not None and node.event_id == 5
+
+    def test_multiturn_text_serial_equivalence(self):
+        """🔴 #5 — 멀티턴 시리얼 케이스에서 두 텍스트 노드가 정확히 격리된다.
+
+        턴1 add_text → mark_completed_and_remove(slot 비움) → 턴2 add_text.
+        이전 dict 모델과 행동 등가 (분석 캐시 §4.1).
+        """
+        nm = SlackNodeMap()
+        # 턴 1
+        nm.add_text(event_id=1, msg_ts="ts_turn1")
+        node1 = nm.find_text_node()
+        assert node1.event_id == 1
+        nm.mark_completed_and_remove(1)
+        assert nm.find_text_node() is None
+        # 턴 2
+        nm.add_text(event_id=2, msg_ts="ts_turn2")
+        node2 = nm.find_text_node()
+        assert node2.event_id == 2
+        # 두 노드는 별개 (msg_ts 다름)
+        assert node1.msg_ts != node2.msg_ts
 
 
 class TestInputRequestNode:
@@ -154,7 +218,7 @@ class TestInputRequestNode:
     def test_input_request_independent_from_regular_nodes(self):
         """input_request 노드는 일반 SlackNode와 독립적"""
         nm = SlackNodeMap()
-        nm.add_thinking(event_id=1, msg_ts="ts-thinking", parent_event_id=None)
+        nm.add_thinking(event_id=1, msg_ts="ts-thinking")
         nm.add_input_request("req-1", "ts-ir", [])
         # 일반 노드 clear가 input_request에 영향 없음
         nm.mark_completed(1)

--- a/tests/presentation/test_progress.py
+++ b/tests/presentation/test_progress.py
@@ -120,7 +120,7 @@ class TestPlaceholder:
             placeholder_ts="ph_ts_001", client=client, initial_board=board,
         )
 
-        await cbs["on_thinking"]("analyzing...", "evt1", None)
+        await cbs["on_thinking"]("analyzing...", "evt1")
 
         # board.add와 schedule_remove가 호출됨
         board.add.assert_called_once()
@@ -144,7 +144,7 @@ class TestPlaceholder:
             placeholder_ts="ph_ts_002", client=client,
         )
 
-        await cbs["on_text_start"]("evt1", None)
+        await cbs["on_text_start"]("evt1")
 
         for c in client.chat_delete.call_args_list:
             assert c != call(channel="C123", ts="ph_ts_002")
@@ -159,10 +159,10 @@ class TestPlaceholder:
         )
 
         # thinking 노드를 먼저 생성
-        await cbs["on_thinking"]("initial", "evt1", None)
+        await cbs["on_thinking"]("initial", "evt1")
         client.chat_delete.reset_mock()
 
-        await cbs["on_text_delta"]("more text", "evt2", None)
+        await cbs["on_text_delta"]("more text", "evt2")
 
         for c in client.chat_delete.call_args_list:
             assert c != call(channel="C123", ts="ph_ts_003")
@@ -176,7 +176,7 @@ class TestPlaceholder:
             placeholder_ts="ph_ts_004", client=client,
         )
 
-        await cbs["on_tool_start"]("Grep", {"pattern": "foo"}, "tu1", "evt1", None)
+        await cbs["on_tool_start"]("Grep", {"pattern": "foo"}, "tu1", "evt1")
 
         for c in client.chat_delete.call_args_list:
             assert c != call(channel="C123", ts="ph_ts_004")
@@ -350,7 +350,7 @@ class TestThinkingComplete:
 
     Phase 3 이후: thinking과 text는 분리되었다.
     - clean 모드: on_text_end는 _placeholder_ts를 사용하여 갱신/삭제
-    - keep 모드: on_text_end는 find_text_node(parent_event_id)로 노드 검색
+    - keep 모드: on_text_end는 find_text_node()로 활성 슬롯 노드 검색
     """
 
     @pytest.mark.asyncio
@@ -362,9 +362,9 @@ class TestThinkingComplete:
         )
 
         # text_start → text_delta → text_end 시퀀스
-        await cbs["on_text_start"]("evt_ts1", None)
-        await cbs["on_text_delta"]("analyzing code...", "evt_td1", None)
-        await cbs["on_text_end"]("evt_text_end", None)
+        await cbs["on_text_start"]("evt_ts1")
+        await cbs["on_text_delta"]("analyzing code...", "evt_td1")
+        await cbs["on_text_end"]("evt_text_end")
 
         # chat_update가 placeholder_msg_ts에 대해 호출됨
         update_calls = [
@@ -393,11 +393,11 @@ class TestThinkingComplete:
         cbs, pctx, node_map, _ = _make_event_cbs(mode="keep", client=client)
 
         # keep 모드: text_start가 새 text 노드를 생성
-        await cbs["on_text_start"]("evt_ts1", "parent_1")
-        await cbs["on_text_delta"]("analyzing...", "evt_td1", "parent_1")
+        await cbs["on_text_start"]("evt_ts1")
+        await cbs["on_text_delta"]("analyzing...", "evt_td1")
 
-        # text_end 트리거 — 같은 parent_event_id
-        await cbs["on_text_end"]("evt_text_end", "parent_1")
+        # text_end 트리거 — 활성 텍스트 슬롯
+        await cbs["on_text_end"]("evt_text_end")
 
         # chat_update가 format_thinking_complete() 결과로 호출됨
         update_calls = [
@@ -428,12 +428,12 @@ class TestToolResult:
         )
 
         # tool 시작 → board.add 호출
-        await cbs["on_tool_start"]("Grep", {"pattern": "error"}, "tu_001", "evt_t1", None)
+        await cbs["on_tool_start"]("Grep", {"pattern": "error"}, "tu_001", "evt_t1")
         board.add.assert_called_once()
         assert board.add.call_args[0][0] == "tool_evt_t1"
 
         # tool 결과 수신 → board.update + schedule_remove 호출
-        await cbs["on_tool_result"]("3 matches found", "tu_001", False, "evt_result", "evt_t1")
+        await cbs["on_tool_result"]("3 matches found", "tu_001", False, "evt_result")
         board.update.assert_called_once()
         assert board.update.call_args[0][0] == "tool_evt_t1"
         assert "Grep" in board.update.call_args[0][1]
@@ -452,10 +452,10 @@ class TestToolResult:
         cbs, pctx, node_map, _ = _make_event_cbs(mode="keep", client=client)
 
         # tool 시작
-        await cbs["on_tool_start"]("Read", {"file_path": "/a/b.py"}, "tu_002", "evt_t2", None)
+        await cbs["on_tool_start"]("Read", {"file_path": "/a/b.py"}, "tu_002", "evt_t2")
 
         # tool 결과 수신
-        await cbs["on_tool_result"]("file content here", "tu_002", False, "evt_result", "evt_t2")
+        await cbs["on_tool_result"]("file content here", "tu_002", False, "evt_result")
 
         # chat_update가 format_tool_result() 결과로 호출됨
         update_calls = [
@@ -478,8 +478,8 @@ class TestToolResult:
         client.chat_postMessage.return_value = {"ts": "tool_msg_ts"}
         cbs, pctx, node_map, _ = _make_event_cbs(mode="keep", client=client)
 
-        await cbs["on_tool_start"]("Bash", {"command": "exit 1"}, "tu_003", "evt_t3", None)
-        await cbs["on_tool_result"]("command failed", "tu_003", True, "evt_result", "evt_t3")
+        await cbs["on_tool_start"]("Bash", {"command": "exit 1"}, "tu_003", "evt_t3")
+        await cbs["on_tool_result"]("command failed", "tu_003", True, "evt_result")
 
         update_calls = [
             c for c in client.chat_update.call_args_list
@@ -731,7 +731,7 @@ class TestThinkingDelete:
             initial_board=board,
         )
 
-        await cbs["on_thinking"]("analyzing...", "evt1", None)
+        await cbs["on_thinking"]("analyzing...", "evt1")
 
         # board.add와 schedule_remove가 호출됨
         board.add.assert_called_once()
@@ -752,7 +752,7 @@ class TestThinkingDelete:
             mode="keep", client=client,
         )
 
-        await cbs["on_thinking"]("analyzing...", "evt1", None)
+        await cbs["on_thinking"]("analyzing...", "evt1")
         await asyncio.sleep(0)
 
         delete_calls = [
@@ -771,7 +771,7 @@ class TestThinkingDelete:
             mode="clean", client=client, placeholder_ts="ph_ts",
         )
 
-        await cbs["on_thinking"]("analyzing...", "evt1", None)
+        await cbs["on_thinking"]("analyzing...", "evt1")
         # 예약된 태스크가 실행 — 예외가 조용히 처리되어야 함
         await asyncio.sleep(0)
 
@@ -781,3 +781,84 @@ class TestThinkingDelete:
             if c[1].get("ts") == "thinking_msg_ts"
         ]
         assert len(delete_calls) == 0
+
+
+class TestKeepModeMultiTurnIsolation:
+    """🔴 #5 / 🔵 #8 — keep 모드 멀티턴 텍스트 격리 검증.
+
+    이전 모델(`_last_text_by_parent[parent_event_id]`) 폐기 후, 단일 활성 슬롯 모델이
+    멀티턴 시리얼 케이스에서 *이전 모델과 등가*임을 white-box로 보호한다.
+    """
+
+    @pytest.mark.asyncio
+    async def test_keep_mode_multiturn_text_isolation(self):
+        """🔴 #5 — keep 모드에서 두 턴의 텍스트가 격리되어 누적된다.
+
+        턴 1: text_start → delta("hello") → end
+        턴 2: text_start → delta("world") → end
+        검증: ts_turn1에 hello만, ts_turn2에 world만 누적된다 (오누적 0건).
+        """
+        client = MagicMock()
+        client.chat_postMessage.side_effect = [
+            {"ts": "ts_turn1"},
+            {"ts": "ts_turn2"},
+        ]
+        cbs, pctx, node_map, _ = _make_event_cbs(mode="keep", client=client)
+
+        # 턴 1
+        await cbs["on_text_start"]("evt1")
+        await cbs["on_text_delta"]("hello", "evt2")
+        await cbs["on_text_end"]("evt3")
+
+        # 턴 2
+        await cbs["on_text_start"]("evt4")
+        await cbs["on_text_delta"]("world", "evt5")
+        await cbs["on_text_end"]("evt6")
+
+        updates_turn1 = [c for c in client.chat_update.call_args_list if c[1].get("ts") == "ts_turn1"]
+        updates_turn2 = [c for c in client.chat_update.call_args_list if c[1].get("ts") == "ts_turn2"]
+
+        # 턴1 메시지에는 hello, 턴2 메시지에는 world가 갱신되어야 한다
+        assert any("hello" in c[1]["text"] for c in updates_turn1), \
+            "turn1 메시지에 hello 누적 실패"
+        assert any("world" in c[1]["text"] for c in updates_turn2), \
+            "turn2 메시지에 world 누적 실패"
+
+        # 오누적 0건 — 턴1 메시지에 world가, 턴2 메시지에 hello가 끼어들지 않는다
+        assert not any("world" in c[1]["text"] for c in updates_turn1), \
+            "turn1 메시지에 world가 잘못 누적됨"
+        assert not any("hello" in c[1]["text"] for c in updates_turn2), \
+            "turn2 메시지에 hello가 잘못 누적됨"
+
+    @pytest.mark.asyncio
+    async def test_keep_mode_parent_none_simulation(self):
+        """🔵 #8 — wire가 parent_event_id를 송출하지 않는 미래 시뮬레이션.
+
+        Phase 2-B-1 재발사 후 (백엔드 fallback 라인 제거 후) 슬랙봇이 받게 될 wire
+        모양을 시뮬레이션. 단일 활성 슬롯 모델은 parent_event_id를 보지 않으므로
+        test_keep_mode_multiturn_text_isolation과 동일하게 동작해야 한다.
+
+        이 케이스는 시그니처 자체에 parent_event_id가 없으므로 wire 변화 후에도
+        멀티턴 등가성이 유지됨을 명시적으로 보호한다.
+        """
+        client = MagicMock()
+        client.chat_postMessage.side_effect = [
+            {"ts": "ts_t1"},
+            {"ts": "ts_t2"},
+        ]
+        cbs, pctx, node_map, _ = _make_event_cbs(mode="keep", client=client)
+
+        # 두 턴 시퀀스 (parent_event_id 무관)
+        await cbs["on_text_start"]("e1")
+        await cbs["on_text_delta"]("alpha", "e2")
+        await cbs["on_text_end"]("e3")
+        await cbs["on_text_start"]("e4")
+        await cbs["on_text_delta"]("beta", "e5")
+        await cbs["on_text_end"]("e6")
+
+        u1 = [c for c in client.chat_update.call_args_list if c[1].get("ts") == "ts_t1"]
+        u2 = [c for c in client.chat_update.call_args_list if c[1].get("ts") == "ts_t2"]
+        assert any("alpha" in c[1]["text"] for c in u1)
+        assert any("beta" in c[1]["text"] for c in u2)
+        assert not any("beta" in c[1]["text"] for c in u1)
+        assert not any("alpha" in c[1]["text"] for c in u2)

--- a/tests/presentation/test_redact.py
+++ b/tests/presentation/test_redact.py
@@ -279,11 +279,11 @@ class TestProgressIntegration:
         cbs = build_event_callbacks(pctx, node_map, mode="keep")
 
         # tool 시작
-        await cbs["on_tool_start"]("Bash", {"command": "cat .env"}, "tu_001", "evt_t1", None)
+        await cbs["on_tool_start"]("Bash", {"command": "cat .env"}, "tu_001", "evt_t1")
 
         # API 키가 포함된 tool 결과
         secret_result = "ANTHROPIC_API_KEY=sk-ant-abcdefghijklmnopqrstu1234567890\nPORT=3000"
-        await cbs["on_tool_result"](secret_result, "tu_001", False, "evt_result", "evt_t1")
+        await cbs["on_tool_result"](secret_result, "tu_001", False, "evt_result")
 
         # chat_update 호출 확인
         update_calls = [
@@ -325,12 +325,12 @@ class TestProgressIntegration:
         cbs = build_event_callbacks(pctx, node_map, mode="keep")
 
         # tool 시작
-        await cbs["on_tool_start"]("Read", {"file_path": "/a/b.py"}, "tu_002", "evt_t2", None)
+        await cbs["on_tool_start"]("Read", {"file_path": "/a/b.py"}, "tu_002", "evt_t2")
 
         # 비문자열 결과 (리스트, 딕셔너리 등)
         non_string_result = [{"type": "text", "text": "content here"}]
         # 예외 없이 처리돼야 함
-        await cbs["on_tool_result"](non_string_result, "tu_002", False, "evt_result2", "evt_t2")
+        await cbs["on_tool_result"](non_string_result, "tu_002", False, "evt_result2")
 
         update_calls = [
             c for c in client.chat_update.call_args_list

--- a/tests/soulstream/test_service_client.py
+++ b/tests/soulstream/test_service_client.py
@@ -1393,7 +1393,7 @@ class TestPersistListening:
         get_response_2.content = _make_stream_reader(b"")
 
         received_deltas = []
-        async def on_text_delta(text, event_id, parent_event_id):
+        async def on_text_delta(text, event_id):
             received_deltas.append(text)
 
         session = self._make_persist_mock_session(


### PR DESCRIPTION
## Summary
- `_last_text_by_parent` dict[parent_event_id, event_id] 매핑을 `_active_text_event_id: Optional[int]` 단일 활성 슬롯으로 교체. soul-app `chatStore.ts`와 동조 (parent 키 미사용).
- 콜백 시그니처(`on_text_*`, `on_tool_*`, `on_thinking`)에서 `parent_event_id` 인자 8건 제거. SSE wire 추출 6건 제거. wire `event.data` dict는 호환성으로 그대로 수신.
- `_remove_from_indexes`에 `node.node_type == "text"` 가드 추가 — invariant를 코드로 명시 (event_id 충돌 방어).

## Why
소울스트림 Phase 2-B-1(백엔드 `task_executor.py:207-209` parent_event_id fallback 라인 제거)의 *선결 카드*. 직전 사이클에서 슬랙봇 `_last_text_by_parent` 강의존이 발견되어 Phase 2-B-1이 반환됐고, 그 의존을 *최소 변경으로* 해소하는 것이 목적.

본 PR 머지 후 wire가 `parent_event_id=None`을 송출해도 슬랙봇 멀티턴 응답이 정상 동작 — `test_keep_mode_parent_none_simulation`이 white-box로 보호.

## Test plan
- [x] `tests/presentation/test_node_map.py` — 기존 14건 갱신 + 신규 5건 (활성 슬롯 덮어쓰기, 슬롯 비움, 다세션 격리, node_type 가드, 멀티턴 시리얼)
- [x] `tests/presentation/test_progress.py` — 콜백 시그니처 갱신 + 신규 2건 (keep 모드 멀티턴 격리, parent=None 시뮬레이션)
- [x] `tests/presentation/test_redact.py`, `tests/soulstream/test_service_client.py` — 콜백 모킹 시그니처 갱신
- [x] 변경 영역 200 테스트 통과
- [x] code-reviewer P0/P1 0건
- [ ] (사용자) 슬랙봇 멀티턴 응답 라이브 회귀 — 머지 후 위임자가 사용자 확인 요청

## Trello
https://trello.com/c/sBrp6OC9

## 후속 작업
- 소울스트림 Phase 2-B-1 재발사 (백엔드 fallback 라인 제거)
- atom 부채 노드 `bcf04dc9-7177-485a-8e68-89be767ee593` 본문 갱신

🤖 Generated with [Claude Code](https://claude.com/claude-code)