### PR TITLE
fix(caller-info): R-4 — plugin_sdk caller_info helper 신설 (G-12)

### DIFF
--- a/src/seosoyoung/plugin_sdk/__init__.py
+++ b/src/seosoyoung/plugin_sdk/__init__.py
@@ -38,6 +38,7 @@ from seosoyoung.plugin_sdk.plugin import (
 from seosoyoung.plugin_sdk import slack
 from seosoyoung.plugin_sdk import soulstream
 from seosoyoung.plugin_sdk import mention
+from seosoyoung.plugin_sdk import caller_info
 
 # Also export commonly used types from submodules
 from seosoyoung.plugin_sdk.slack import (
@@ -57,6 +58,10 @@ from seosoyoung.plugin_sdk.soulstream import (
 from seosoyoung.plugin_sdk.mention import (
     MentionTrackingBackend,
 )
+from seosoyoung.plugin_sdk.caller_info import (
+    build_bot_caller_info,
+    get_host_preferred_node,
+)
 
 __all__ = [
     # Core plugin types
@@ -70,6 +75,7 @@ __all__ = [
     "slack",
     "soulstream",
     "mention",
+    "caller_info",
     # Slack types
     "Message",
     "ReactionResult",
@@ -84,4 +90,7 @@ __all__ = [
     "SoulstreamBackend",
     # Mention types
     "MentionTrackingBackend",
+    # Caller info helpers (R-4 atom G-12, G-14)
+    "build_bot_caller_info",
+    "get_host_preferred_node",
 ]

--- a/src/seosoyoung/plugin_sdk/caller_info.py
+++ b/src/seosoyoung/plugin_sdk/caller_info.py
@@ -44,7 +44,7 @@ def build_bot_caller_info(
 
     soul_common.auth.caller_info.build_bot_caller_info의 plugin-side 동등 구현.
     plugin_sdk가 soul_common을 직접 import하지 않도록 *복제 구현* — cross-import
-    회귀 테스트(`tests/test_plugin_sdk_caller_info_signature.py`)가 두 정본의
+    회귀 테스트(`seosoyoung-plugins/tests/test_caller_info_signature_regression.py`)가 두 정본의
     시그니처·반환 dict 정합을 보장한다.
 
     호출 정본:

--- a/src/seosoyoung/plugin_sdk/caller_info.py
+++ b/src/seosoyoung/plugin_sdk/caller_info.py
@@ -1,0 +1,102 @@
+"""Caller info API for plugins.
+
+Plugins use this to build `caller_info` v1 dicts for `soulstream.run(caller_info=...)`
+calls. The host (soul-server) interprets the dict against
+`soul_common.auth.caller_info` (same v1 schema, atom `ed3a216d`).
+
+R-4 fix(2026-05-11, atom G-12): plugin이 자기 source 정체성을 박을 때 dict 복제 패턴
+(`{"source": ..., "display_name": ..., ...}`)을 helper로 통합. soul_common.auth.caller_info
+정본과 *동등 구현* — plugin_sdk는 soul_common을 직접 import하지 않는다 (§1 plugin이 host
+내부 모듈 모름). 시그니처·반환 dict 정합은 cross-import 회귀 테스트로 보장한다.
+
+Usage:
+    from seosoyoung.plugin_sdk import caller_info
+
+    info = caller_info.build_bot_caller_info(
+        source="channel_observer",
+        display_name="채널 관찰자",
+        agent_node=host_config.preferred_node or None,
+    )
+    result = await soulstream.run(prompt=..., caller_info=info)
+
+정본 (host 측):
+- `soul_common.auth.caller_info.build_bot_caller_info` (시그니처 정합 정본)
+- caller_info v1 스키마: atom `ed3a216d`
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+# soul_common.auth.caller_info.SYSTEM_PORTRAIT_BASE와 동일 값. cross-import 회귀 테스트가
+# 두 정본의 값이 정합한지 보장.
+SYSTEM_PORTRAIT_BASE = "/api/system/portraits"
+
+
+def build_bot_caller_info(
+    *,
+    source: str,
+    display_name: str,
+    agent_node: Optional[str] = None,
+) -> dict[str, Any]:
+    """자동 봇(channel_observer / trello_watcher) source의 caller_info 조립 (통합 v1).
+
+    soul_common.auth.caller_info.build_bot_caller_info의 plugin-side 동등 구현.
+    plugin_sdk가 soul_common을 직접 import하지 않도록 *복제 구현* — cross-import
+    회귀 테스트(`tests/test_plugin_sdk_caller_info_signature.py`)가 두 정본의
+    시그니처·반환 dict 정합을 보장한다.
+
+    호출 정본:
+    - `seosoyoung-plugins/.../channel_observer/pipeline.py` — channel_observer
+    - `seosoyoung-plugins/.../trello/watcher.py` — trello_watcher
+
+    Args:
+        source: 봇 source 토큰. host(soul-server)의 ALLOWED_SOURCES + _PORTRAIT_FILE_MAP
+            (`orch-server/.../api/system_portraits.py`)에 등록되어야 함.
+        display_name: 사용자 표시명 (예: '채널 관찰자', '트렐로 워처').
+        agent_node: (옵션, R-4 atom G-14) 봇이 실행되는 노드 ID. plugin 호출자(host)가
+            `Config.orchestrator.preferred_node or None`을 전달. truthy일 때만
+            caller_info에 키 포함 — graceful (자동 라우팅 시 None 유지).
+
+    Returns:
+        v1 caller_info dict — source/display_name/avatar_url 채움, user_id None.
+        agent_node는 옵션 인자 truthy일 때만 포함.
+    """
+    info: dict[str, Any] = {
+        "source": source,
+        "display_name": display_name,
+        "user_id": None,
+        "avatar_url": f"{SYSTEM_PORTRAIT_BASE}/{source}",
+    }
+    if agent_node:
+        info["agent_node"] = agent_node
+    return info
+
+
+def get_host_preferred_node() -> Optional[str]:
+    """Host(seosoyoung 슬랙봇)의 preferred_node를 동적으로 조회 (R-4, atom G-14).
+
+    Plugin이 자기 `caller_info.agent_node`에 박을 노드 ID를 host config에서 *자연 조회*한다.
+    plugin이 `Config` singleton 또는 환경변수를 직접 import하지 않도록 plugin_sdk가 wrapping
+    — plugin은 plugin_sdk만 import (§1 지식 경계 추상화 보존).
+
+    `handlers/node.py:_update_preferred_node`로 *런타임에 dynamic 변경*되는 값이므로 매 호출
+    시점에 최신 값을 반환 (plugins.yaml의 *snapshot* config 패턴 대비 정합).
+
+    Returns:
+        Host의 `Config.orchestrator.preferred_node` — truthy면 노드 ID, None이면:
+        - 자동 라우팅 모드 (`SOULSTREAM_PREFERRED_NODE` 미설정)
+        - Config 모듈 import 실패 (test 환경 등 plugin_sdk가 호스트 외부에서 로드된 경우)
+
+    호출 정본:
+    - `seosoyoung-plugins/.../channel_observer/pipeline.py` — caller_info.agent_node 채움
+    - `seosoyoung-plugins/.../trello/watcher.py` — 동
+    """
+    try:
+        from seosoyoung.slackbot.config import Config
+
+        return Config.orchestrator.preferred_node or None
+    except (ImportError, AttributeError):
+        # plugin_sdk가 host 외부에서 로드되는 환경(unit test 등) — graceful None.
+        return None

--- a/tests/test_plugin_sdk_caller_info.py
+++ b/tests/test_plugin_sdk_caller_info.py
@@ -1,0 +1,133 @@
+"""plugin_sdk/caller_info 단위 테스트 (R-4, atom G-12 + G-14).
+
+R-4 fix(2026-05-11): plugin_sdk가 build_bot_caller_info를 noemus_common 정본과 *동등
+구현*으로 노출. plugin이 host 내부 모듈을 직접 import하지 않도록 plugin_sdk가 wrapping
+(§1 지식 경계 추상화).
+
+cross-import 정합(soul_common helper와 시그니처·반환 dict 일치)은 *seosoyoung-plugins*
+tests의 test_caller_info_signature_regression.py가 검증한다.
+
+본 파일은 plugin_sdk *단독* 정합 — build_bot_caller_info의 입출력 단위·get_host_preferred_node의
+graceful import 동작.
+"""
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from seosoyoung.plugin_sdk.caller_info import (
+    SYSTEM_PORTRAIT_BASE,
+    build_bot_caller_info,
+    get_host_preferred_node,
+)
+
+
+class TestBuildBotCallerInfoUnit:
+    """plugin_sdk build_bot_caller_info 단위 — soul_common 의존성 없이 단독 검증."""
+
+    def test_channel_observer_minimal_dict(self):
+        """source + display_name만 → v1 dict 4키, agent_node 키 부재."""
+        result = build_bot_caller_info(
+            source="channel_observer",
+            display_name="채널 관찰자",
+        )
+        assert result == {
+            "source": "channel_observer",
+            "display_name": "채널 관찰자",
+            "user_id": None,
+            "avatar_url": "/api/system/portraits/channel_observer",
+        }
+
+    def test_trello_watcher_minimal_dict(self):
+        """trello_watcher source 동일 패턴."""
+        result = build_bot_caller_info(
+            source="trello_watcher",
+            display_name="트렐로 워처",
+        )
+        assert result == {
+            "source": "trello_watcher",
+            "display_name": "트렐로 워처",
+            "user_id": None,
+            "avatar_url": "/api/system/portraits/trello_watcher",
+        }
+
+    def test_agent_node_truthy_included(self):
+        """agent_node truthy → caller_info에 키 포함 (R-4 G-14)."""
+        result = build_bot_caller_info(
+            source="channel_observer",
+            display_name="채널 관찰자",
+            agent_node="eias-linegames",
+        )
+        assert result["agent_node"] == "eias-linegames"
+
+    @pytest.mark.parametrize("falsy", [None, ""])
+    def test_agent_node_falsy_omitted(self, falsy):
+        """agent_node falsy(None/빈 문자열) → 키 부재 (graceful)."""
+        result = build_bot_caller_info(
+            source="channel_observer",
+            display_name="채널 관찰자",
+            agent_node=falsy,
+        )
+        assert "agent_node" not in result
+
+    def test_avatar_url_pattern(self):
+        """avatar_url = SYSTEM_PORTRAIT_BASE + source — 라우트 정합."""
+        result = build_bot_caller_info(
+            source="custom_bot",
+            display_name="Custom Bot",
+        )
+        assert result["avatar_url"] == f"{SYSTEM_PORTRAIT_BASE}/custom_bot"
+
+    def test_keyword_only_args(self):
+        """source/display_name keyword-only → positional 호출 TypeError."""
+        try:
+            build_bot_caller_info("channel_observer", "채널 관찰자")  # type: ignore[misc]
+        except TypeError:
+            return
+        raise AssertionError("positional 호출이 TypeError를 일으켜야 한다")
+
+
+class TestSystemPortraitBaseConstant:
+    """SYSTEM_PORTRAIT_BASE 상수 — orch 라우트 prefix와 정합."""
+
+    def test_value(self):
+        """`/api/system/portraits` — orch-server `create_system_portraits_router` prefix."""
+        assert SYSTEM_PORTRAIT_BASE == "/api/system/portraits"
+
+
+class TestGetHostPreferredNode:
+    """R-4 (atom G-14): get_host_preferred_node — host config 동적 조회 helper."""
+
+    def test_returns_config_value_when_truthy(self):
+        """Config.orchestrator.preferred_node truthy → 그 값 반환."""
+        # Config 모듈을 mock으로 패치 — preferred_node 값 주입
+        from seosoyoung.slackbot.config import Config
+
+        with patch.object(Config.orchestrator, "preferred_node", "eias-shopping"):
+            result = get_host_preferred_node()
+            assert result == "eias-shopping"
+
+    def test_returns_none_when_empty_string(self):
+        """Config.orchestrator.preferred_node = "" (default) → None (graceful, 자동 라우팅)."""
+        from seosoyoung.slackbot.config import Config
+
+        with patch.object(Config.orchestrator, "preferred_node", ""):
+            result = get_host_preferred_node()
+            assert result is None
+
+    def test_returns_none_when_config_import_fails(self):
+        """Config 모듈 import 실패(test 환경 등) → graceful None."""
+        # Config 모듈을 sys.modules에서 임시 제거하여 ImportError 시뮬레이션
+        original_modules = {
+            k: v for k, v in sys.modules.items()
+            if k.startswith("seosoyoung.slackbot.config")
+        }
+        # block import by registering None — Python ImportError on re-import
+        with patch.dict(sys.modules, {"seosoyoung.slackbot.config": None}):
+            # get_host_preferred_node 내부의 import 시 ImportError 또는 AttributeError
+            result = get_host_preferred_node()
+            assert result is None
+        # cleanup — 원상복구
+        for k, v in original_modules.items():
+            sys.modules[k] = v


### PR DESCRIPTION
## 요약

caller_info R-4 번들의 seosoyoung 본체 측 fix. plugin이 dict 리터럴로 caller_info를 복제하던 *정본 둘 안티패턴*(atom `d7a1ad86`)을 plugin_sdk SDK 인터페이스로 닫음.

- `seosoyoung/src/seosoyoung/plugin_sdk/caller_info.py` 신설 — `build_bot_caller_info` (soul-common 시그니처 정합) + `get_host_preferred_node` (host config에서 노드 ID 동적 조회)
- plugin 측(seosoyoung-plugins)이 본 SDK helper 호출 — soul-common 직접 의존성 회피 (§1 지식 경계)

## 검증

- plugin_sdk 단위 회귀 11 GREEN
- soul-common 시그니처 정합 cross-import 7 GREEN
- code-reviewer agentId `a7c8cedcb39085d2f` 통과 (P0/P1 0건). cross-import 회귀가 §3 정본 둘 패턴을 *test-then-fail*로 무력화

## 관련 PR

- soulstream `fix/caller-info-r4-bundle` — soul-common build_bot_caller_info 정본 (선행 머지)
- seosoyoung-plugins `fix/caller-info-r4-bundle` — plugin_sdk helper 사용 (후행 머지)

## Test plan

- [x] plugin_sdk 11 GREEN
- [x] cross-import 7 GREEN
- [x] code-reviewer 통과
- [ ] 머지·배포 후 plugin 정상 작동 (channel_observer / trello_watcher import 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)