### PR TITLE
feat: RunResult.transcript + text_only 누적 (utterance 게이트 인프라)

### DIFF
--- a/src/seosoyoung/plugin_sdk/caller_info.py
+++ b/src/seosoyoung/plugin_sdk/caller_info.py
@@ -107,6 +107,9 @@ def get_host_preferred_node() -> Optional[str]:
         from seosoyoung.slackbot.config import Config
 
         return Config.orchestrator.preferred_node or None
-    except (ImportError, AttributeError):
+    except (ImportError, AttributeError, KeyError):
         # plugin_sdk가 host 외부에서 로드되는 환경(unit test 등) — graceful None.
+        # KeyError: Config import 시점에 SlackConfig가 OPERATOR_USER_ID 등 envvar를
+        # `os.environ[...]`로 즉시 검증 → unit test에 envvar 없으면 KeyError.
+        # docstring의 graceful None 약속을 envvar 부재 케이스로 확장.
         return None

--- a/src/seosoyoung/plugin_sdk/caller_info.py
+++ b/src/seosoyoung/plugin_sdk/caller_info.py
@@ -112,4 +112,8 @@ def get_host_preferred_node() -> Optional[str]:
         # KeyError: Config import 시점에 SlackConfig가 OPERATOR_USER_ID 등 envvar를
         # `os.environ[...]`로 즉시 검증 → unit test에 envvar 없으면 KeyError.
         # docstring의 graceful None 약속을 envvar 부재 케이스로 확장.
+        # NOTE: 프로덕션 슬랙봇이 정상 부팅한 뒤에는 Config singleton이 이미 import
+        #       완료된 상태이므로 본 호출 경로에서 KeyError가 발생할 시점이 없다.
+        #       본 catch는 test 환경 전용 graceful path이며, 프로덕션 silent
+        #       degrade는 발생하지 않는다.
         return None

--- a/src/seosoyoung/plugin_sdk/soulstream.py
+++ b/src/seosoyoung/plugin_sdk/soulstream.py
@@ -62,6 +62,21 @@ class RunResult:
     session_id: str | None = None
     error: str = ""
     output: str = ""
+    transcript: str = ""
+    """text_only 모드에서만 채워지는 누적 텍스트 (thinking + 중간 text_delta + final output).
+
+    채널 개입(channel_observer)처럼 본체 Claude Code 세션의 *전체* assistant 출력
+    어디든 `<utterance>` 태그를 검색해야 하는 호출자를 위해 backend가 자체적으로
+    누적하여 노출한다. 비-text_only 모드 또는 옛 backend에서는 빈 문자열.
+
+    호출자는 다음 패턴으로 graceful degrade한다 (옛 backend 호환):
+        source = getattr(result, "transcript", "") or result.output or ""
+
+    조립 순서는 thinking 묶음 + text_delta 묶음 + output이며, *발화 순서를
+    보존하지 않는다*. utterance 추출은 ``re.findall``이 텍스트 어디든 잡아내므로
+    파싱 결과에 영향 없음. transcript를 디버그·UI 표시 용도로 쓰는 호출자가
+    생기면 그때 SSE 순서 보존 정책을 별도 결정한다.
+    """
 
 
 @dataclass

--- a/src/seosoyoung/slackbot/plugin_backends.py
+++ b/src/seosoyoung/slackbot/plugin_backends.py
@@ -419,8 +419,11 @@ class SoulstreamBackendImpl(SoulstreamBackend):
                 #   `await on_text_delta(...)` 호출은 그 새 이벤트 루프 안에서
                 #   발생하므로 async 콜백 정의는 안전.
                 #   누적기는 list.append만 수행하여 GIL로 thread-safe.
-                caller_on_text_delta = kwargs.get("on_text_delta")
-                caller_on_thinking = kwargs.get("on_thinking")
+                # kwargs.pop으로 빼서 비-text_only 분기 진입 시(이 분기는 take되지
+                # 않지만, 안전상) executor에 중복 전달되지 않도록 정리. 본 분기 안에서는
+                # 누적기로 wrap한 콜백만 executor에 전달한다 (정본 하나).
+                caller_on_text_delta = kwargs.pop("on_text_delta", None)
+                caller_on_thinking = kwargs.pop("on_thinking", None)
 
                 async def _accumulate_text(text, _eid):
                     accumulated_text.append(text or "")

--- a/src/seosoyoung/slackbot/plugin_backends.py
+++ b/src/seosoyoung/slackbot/plugin_backends.py
@@ -399,6 +399,10 @@ class SoulstreamBackendImpl(SoulstreamBackend):
             # text_only=False일 때는 None이 정상 — executor가 _process_result()로 자체 처리.
             on_result_fn = None
 
+            # transcript 누적기 (text_only 모드에서만 사용)
+            accumulated_thinking: list[str] = []
+            accumulated_text: list[str] = []
+
             if text_only:
                 # text_only 모드: presentation 없이 실행하여 슬랙 게시를 건너뜀
                 # on_result 콜백으로 출력 텍스트를 캡처
@@ -406,6 +410,27 @@ class SoulstreamBackendImpl(SoulstreamBackend):
 
                 def capture_result(result, _thread_ts, _user_message):
                     captured_output.append(result.output or "")
+
+                # async/sync 경계 안전성 근거:
+                #   self._executor 내부는 run_in_new_loop(coro) →
+                #   별도 스레드에서 asyncio.run으로 새 이벤트 루프를 띄워 SSE 처리
+                #   코루틴을 실행한다 (utils/async_bridge.py:13-43).
+                #   service_client.py:806/819에서 `await on_thinking(...)` /
+                #   `await on_text_delta(...)` 호출은 그 새 이벤트 루프 안에서
+                #   발생하므로 async 콜백 정의는 안전.
+                #   누적기는 list.append만 수행하여 GIL로 thread-safe.
+                caller_on_text_delta = kwargs.get("on_text_delta")
+                caller_on_thinking = kwargs.get("on_thinking")
+
+                async def _accumulate_text(text, _eid):
+                    accumulated_text.append(text or "")
+                    if caller_on_text_delta:
+                        await caller_on_text_delta(text, _eid)
+
+                async def _accumulate_thinking(text, _eid):
+                    accumulated_thinking.append(text or "")
+                    if caller_on_thinking:
+                        await caller_on_thinking(text, _eid)
 
                 await loop.run_in_executor(
                     None,
@@ -419,6 +444,8 @@ class SoulstreamBackendImpl(SoulstreamBackend):
                         role=role,
                         context=context,
                         on_result=capture_result,
+                        on_text_delta=_accumulate_text,
+                        on_thinking=_accumulate_thinking,
                         model=model,
                         folder_id=_folder_id,
                         system_prompt=_system_prompt,
@@ -495,11 +522,23 @@ class SoulstreamBackendImpl(SoulstreamBackend):
             new_session_id = session.session_id if session else session_id
             output = captured_output[0] if (text_only and captured_output) else ""
 
+            # transcript는 text_only 모드에서만 누적된다.
+            # 조립 순서: thinking 묶음 + text_delta 묶음 + final output.
+            # *발화 순서를 보존하지 않는다* — utterance 추출은 re.findall이
+            # 텍스트 어디든 잡아내므로 순서 무관. RunResult.transcript docstring 참조.
+            transcript = (
+                ("".join(accumulated_thinking)
+                 + "".join(accumulated_text)
+                 + (("\n" + output) if output else ""))
+                if text_only else ""
+            )
+
             return RunResult(
                 ok=True,
                 status=RunStatus.COMPLETED,
                 session_id=new_session_id,
                 output=output,
+                transcript=transcript,
             )
         except Exception as e:
             logger.error(f"soulstream.run failed: {e}")


### PR DESCRIPTION
## Summary

채널 개입 응답이 슬랙에 게시될 때 `<utterance>` 태그 안 본문만 추출되어야 한다는 명세(channel-intervene SKILL.md §6)와 실제 동작 불일치를 backend 측에서 차단한다. 사고 사례: 2026-05-13 C08HX0Z475M ts 1778666880.753679 — 본체 LLM final output에 utterance 태그가 없어 sub-agent 작업 보고 전체가 채널에 누출.

본 PR(R1)은 backend의 누적 텍스트 노출 인프라를 담당하고, 실제 게이트는 짝 PR(seosoyoung-plugins#feature/channel-intervene-utterance-only)에서 적용한다.

- `RunResult.transcript: str = ""` 필드 추가 — text_only 모드에서만 채워지는 누적 텍스트(thinking + 중간 text_delta + final output). 비-text_only 모드와 옛 호출자에 backward-compatible.
- `SoulstreamBackendImpl.run`의 text_only 분기에 thinking/text_delta 누적기 추가. SSE 콜백은 `run_in_new_loop`의 새 이벤트 루프 안에서 await되므로 async 정의 안전, `list.append`는 GIL로 thread-safe.
- `caller_info.get_host_preferred_node`의 except에 `KeyError` 추가 — docstring graceful None 약속을 envvar 부재 케이스로 확장(test 환경 전용 path, 프로덕션 부팅 후에는 발생 시점 없음).

## Test plan

- [x] `tests/test_plugin_backends.py` + `tests/test_plugin_sdk_soulstream.py` 33개 통과 (회귀 0).
- [x] 본 PR의 짝 PR(seosoyoung-plugins) 측 channel_observer 104개 + utterance 게이트 단위 테스트 6개 + dedupe 테스트 3개 통과.
- [ ] (사용자) 머지·배포 후 실제 채널 개입 시 utterance 태그 안 텍스트만 게시되는지 확인.
- [ ] (사용자) 배포 순서: 본 PR 선행 → seosoyoung-plugins PR 후행 (R2 측 `getattr` fallback이 옛 backend와도 graceful하지만, 본 PR 머지 전에는 utterance 게이트 강화 효과 0).

## 분석 캐시

- 시스템 그림: `roselin/.local/artifacts/analysis/20260513-1020-channel-intervene-utterance-system-map.md`
- 설계: `roselin/.local/artifacts/analysis/20260513-1100-channel-intervene-utterance-design.md`

Refs trello: https://trello.com/c/TVDf1AN6