### PR TITLE
채널 개입 응답 분석 텍스트 누출 차단 (블록 단위 utterance 게이트)

### DIFF
--- a/src/seosoyoung/plugin_sdk/soulstream.py
+++ b/src/seosoyoung/plugin_sdk/soulstream.py
@@ -62,20 +62,25 @@ class RunResult:
     session_id: str | None = None
     error: str = ""
     output: str = ""
-    transcript: str = ""
-    """text_only 모드에서만 채워지는 누적 텍스트 (thinking + 중간 text_delta + final output).
+    utterances: list[str] = field(default_factory=list)
+    """text_only 모드에서만 채워지는 *블록 단위* ``<utterance>`` 매치 list (사이클 260518.01).
 
-    채널 개입(channel_observer)처럼 본체 Claude Code 세션의 *전체* assistant 출력
-    어디든 `<utterance>` 태그를 검색해야 하는 호출자를 위해 backend가 자체적으로
-    누적하여 노출한다. 비-text_only 모드 또는 옛 backend에서는 빈 문자열.
+    backend가 SSE 이벤트의 *블록 종료 시점*에 그 블록 텍스트 안에서만
+    ``<utterance>(.*?)</utterance>`` non-greedy 매치를 돌려 strip된 본문을 list에
+    누적한다. 블록 정의:
 
-    호출자는 다음 패턴으로 graceful degrade한다 (옛 backend 호환):
-        source = getattr(result, "transcript", "") or result.output or ""
+    - **thinking 블록**: 한 ``thinking`` 이벤트의 텍스트 1건.
+    - **text 블록**: ``text_start`` → N× ``text_delta`` → ``text_end`` 트리오로 묶인 한 덩이.
+    - **complete 블록**: 본체 final output (``output`` 필드의 내용).
 
-    조립 순서는 thinking 묶음 + text_delta 묶음 + output이며, *발화 순서를
-    보존하지 않는다*. utterance 추출은 ``re.findall``이 텍스트 어디든 잡아내므로
-    파싱 결과에 영향 없음. transcript를 디버그·UI 표시 용도로 쓰는 호출자가
-    생기면 그때 SSE 순서 보존 정책을 별도 결정한다.
+    *직전 사이클*(260513.01)의 ``transcript`` 누적 정책을 폐기한다 — 누적 transcript에서
+    thinking 묶음의 우발 ``<utterance>`` 토큰이 text 묶음의 정상 ``</utterance>`` 닫힘
+    태그와 인접하여 한 덩이 매치로 분석 텍스트 전체를 흘리는 사고를 차단한다.
+
+    빈 매치(``<utterance></utterance>``) 항목은 ``""``로 list에 포함된다 — 호출자가
+    빈 문자열 필터·dedupe·게시 정책을 결정한다 (책임 분리). 매치가 없으면 빈 list.
+
+    비-text_only 모드에서는 빈 list (backend가 본 필드를 채우지 않음).
     """
 
 

--- a/src/seosoyoung/plugin_sdk/utterance.py
+++ b/src/seosoyoung/plugin_sdk/utterance.py
@@ -1,0 +1,41 @@
+"""`<utterance>...</utterance>` 짝 추출 pure 유틸 (사이클 260518.01).
+
+본 모듈은 *블록 단위 utterance 게이트*의 정본 매처다. 호출자는 thinking 블록 /
+text 블록 (text_start ~ text_end 트리오) / complete 블록 (final output) *각각의
+텍스트만* 넘긴다. 그 결과 한 블록의 우발 ``<utterance>`` 토큰이 다른 블록의
+닫힘 태그와 짝지어지지 않는다.
+
+직전 사이클(260513.01)의 *누적 transcript 검색* 정책은 사고 사례 (세션
+``c2a12c38-9ab3-4d78-ba1f-3f5fca94c418`` / 채널 ``C08KT1HDU5U``)에서 본체 Opus가
+thinking에 ``"Output the utterance in <utterance> tags."`` 같은 메타 설명을 적어
+우발 토큰이 등장 → text 묶음의 정상 ``</utterance>``와 인접 → 한 덩이 매치로
+약 1.5 KB 분석 텍스트 전체를 슬랙에 누출했다 (R7 위임자 확인). 본 사이클은
+누적 자체를 *애초에 만들지 않음*으로써 차단한다.
+
+책임 분리:
+- 본 유틸은 *strip된 매치 본문 list*만 반환한다 (dedupe 안 함).
+- 빈 utterance(``<utterance></utterance>``)는 strip 후 빈 문자열로 list에 포함된다.
+- 빈 문자열 필터 / dedupe / 등장 순서 / 게시 정책은 호출자가 결정한다.
+"""
+
+from __future__ import annotations
+
+import re
+
+_UTTERANCE_RE = re.compile(r"<utterance>(.*?)</utterance>", re.DOTALL)
+
+
+def extract_utterance_matches(text: str | None) -> list[str]:
+    """주어진 텍스트에서 ``<utterance>(.*?)</utterance>`` 매치를 strip된 list로 반환.
+
+    Args:
+        text: 한 블록의 텍스트 (thinking 이벤트 본문 / text 블록 buffer / final output).
+            ``None`` 또는 빈 문자열이면 빈 list.
+
+    Returns:
+        매치된 본문들의 list. 각 본문은 ``str.strip()`` 적용 후 담긴다.
+        매치가 없으면 빈 list. 빈 utterance 태그는 ``""`` 항목으로 list에 포함된다.
+    """
+    if not text:
+        return []
+    return [m.strip() for m in _UTTERANCE_RE.findall(text)]

--- a/src/seosoyoung/slackbot/plugin_backends.py
+++ b/src/seosoyoung/slackbot/plugin_backends.py
@@ -425,11 +425,27 @@ class SoulstreamBackendImpl(SoulstreamBackend):
                 # 게이트 콜백만 executor에 전달한다 (정본 하나).
                 caller_on_text_delta = kwargs.pop("on_text_delta", None)
                 caller_on_thinking = kwargs.pop("on_thinking", None)
+                caller_on_text_start = kwargs.pop("on_text_start", None)
                 caller_on_text_end = kwargs.pop("on_text_end", None)
 
                 from seosoyoung.plugin_sdk.utterance import (
                     extract_utterance_matches,
                 )
+
+                def _flush_text_buffer() -> None:
+                    """잔여 buffer를 추출·비움. text_start / text_end / 종료 fallback에서 공통 사용.
+
+                    SSE 이벤트가 사실상 단일 thread 순차 처리되어 ``text_end`` 누락은
+                    드물지만, 블록 경계 boundary signal로 ``text_start``를 추가해
+                    두 트리오의 텍스트가 한 블록으로 잘못 합쳐지는 동질 결함을 차단한다
+                    (code-reviewer P2 권고, 사이클 260518.01).
+                    """
+                    if text_block_buffer:
+                        block_text = "".join(text_block_buffer)
+                        text_block_buffer.clear()
+                        captured_utterances.extend(
+                            extract_utterance_matches(block_text)
+                        )
 
                 def capture_result(result, _thread_ts, _user_message):
                     out = result.output or ""
@@ -447,6 +463,13 @@ class SoulstreamBackendImpl(SoulstreamBackend):
                     if caller_on_thinking:
                         await caller_on_thinking(text, _eid)
 
+                async def _on_text_start_block(_eid):
+                    # 새 text 블록 진입 — 직전 블록 buffer에 잔여가 있으면 먼저 flush.
+                    # ``text_end`` 누락 시 두 트리오가 한 블록으로 합쳐지는 결함 차단.
+                    _flush_text_buffer()
+                    if caller_on_text_start:
+                        await caller_on_text_start(_eid)
+
                 async def _on_text_delta_buffer(text, _eid):
                     # text 블록 진행 중 — buffer에 누적만. 매치는 text_end에서.
                     if text:
@@ -456,12 +479,7 @@ class SoulstreamBackendImpl(SoulstreamBackend):
 
                 async def _on_text_end_block(_eid):
                     # text 블록 종료 — buffer 전체에서 매치 검색 후 비움.
-                    if text_block_buffer:
-                        block_text = "".join(text_block_buffer)
-                        text_block_buffer.clear()
-                        captured_utterances.extend(
-                            extract_utterance_matches(block_text)
-                        )
+                    _flush_text_buffer()
                     if caller_on_text_end:
                         await caller_on_text_end(_eid)
 
@@ -477,6 +495,7 @@ class SoulstreamBackendImpl(SoulstreamBackend):
                         role=role,
                         context=context,
                         on_result=capture_result,
+                        on_text_start=_on_text_start_block,
                         on_text_delta=_on_text_delta_buffer,
                         on_text_end=_on_text_end_block,
                         on_thinking=_on_thinking_block,
@@ -558,7 +577,8 @@ class SoulstreamBackendImpl(SoulstreamBackend):
 
             # 누락 보호: text 블록이 ``text_end`` 없이 종료된 케이스(SSE 비정상 종료 등)에
             # 대비하여 잔여 buffer에서도 마지막 한 번 매치 검색.
-            # 정상 흐름에서는 ``_on_text_end_block``이 buffer를 비웠으므로 no-op.
+            # 정상 흐름에서는 ``_on_text_end_block`` / ``_on_text_start_block``의
+            # ``_flush_text_buffer``가 buffer를 비웠으므로 no-op.
             if text_only and text_block_buffer:
                 from seosoyoung.plugin_sdk.utterance import (
                     extract_utterance_matches,

--- a/src/seosoyoung/slackbot/plugin_backends.py
+++ b/src/seosoyoung/slackbot/plugin_backends.py
@@ -399,41 +399,71 @@ class SoulstreamBackendImpl(SoulstreamBackend):
             # text_only=False일 때는 None이 정상 — executor가 _process_result()로 자체 처리.
             on_result_fn = None
 
-            # transcript 누적기 (text_only 모드에서만 사용)
-            accumulated_thinking: list[str] = []
-            accumulated_text: list[str] = []
+            # 블록 단위 utterance 매치 누적 (text_only 모드에서만 사용).
+            # 사이클 260518.01: 누적 transcript 정책 폐기 — thinking / text_start~end /
+            # complete 각 블록의 *그 블록 텍스트만*에서 ``<utterance>`` 매치 추출.
+            # 우발 토큰이 다른 블록의 닫힘 태그와 짝지어지지 않는다.
+            captured_utterances: list[str] = []
+            # text 블록 버퍼 — text_start ~ text_end 사이 delta 누적, text_end에서 처리.
+            text_block_buffer: list[str] = []
 
             if text_only:
                 # text_only 모드: presentation 없이 실행하여 슬랙 게시를 건너뜀
                 # on_result 콜백으로 출력 텍스트를 캡처
                 captured_output: list[str] = []
 
-                def capture_result(result, _thread_ts, _user_message):
-                    captured_output.append(result.output or "")
-
                 # async/sync 경계 안전성 근거:
                 #   self._executor 내부는 run_in_new_loop(coro) →
                 #   별도 스레드에서 asyncio.run으로 새 이벤트 루프를 띄워 SSE 처리
                 #   코루틴을 실행한다 (utils/async_bridge.py:13-43).
-                #   service_client.py:806/819에서 `await on_thinking(...)` /
-                #   `await on_text_delta(...)` 호출은 그 새 이벤트 루프 안에서
-                #   발생하므로 async 콜백 정의는 안전.
-                #   누적기는 list.append만 수행하여 GIL로 thread-safe.
+                #   service_client.py에서 ``await on_thinking(...)`` /
+                #   ``await on_text_delta(...)`` / ``await on_text_end(...)`` 호출은
+                #   그 새 이벤트 루프 안에서 발생하므로 async 콜백 정의는 안전.
+                #   누적기는 list.append/extend만 수행하여 GIL로 thread-safe.
                 # kwargs.pop으로 빼서 비-text_only 분기 진입 시(이 분기는 take되지
                 # 않지만, 안전상) executor에 중복 전달되지 않도록 정리. 본 분기 안에서는
-                # 누적기로 wrap한 콜백만 executor에 전달한다 (정본 하나).
+                # 게이트 콜백만 executor에 전달한다 (정본 하나).
                 caller_on_text_delta = kwargs.pop("on_text_delta", None)
                 caller_on_thinking = kwargs.pop("on_thinking", None)
+                caller_on_text_end = kwargs.pop("on_text_end", None)
 
-                async def _accumulate_text(text, _eid):
-                    accumulated_text.append(text or "")
+                from seosoyoung.plugin_sdk.utterance import (
+                    extract_utterance_matches,
+                )
+
+                def capture_result(result, _thread_ts, _user_message):
+                    out = result.output or ""
+                    captured_output.append(out)
+                    # complete 블록: final output 안에서도 매치 검색.
+                    # text 블록에 이미 같은 본문이 잡혔어도 backend는 dedupe하지 않는다 —
+                    # 호출자(``_execute_intervene``)가 strip 동일성으로 1회만 게시.
+                    if out:
+                        captured_utterances.extend(extract_utterance_matches(out))
+
+                async def _on_thinking_block(text, _eid):
+                    # thinking 블록: 한 이벤트 = 한 블록. 즉시 매치 검색.
+                    if text:
+                        captured_utterances.extend(extract_utterance_matches(text))
+                    if caller_on_thinking:
+                        await caller_on_thinking(text, _eid)
+
+                async def _on_text_delta_buffer(text, _eid):
+                    # text 블록 진행 중 — buffer에 누적만. 매치는 text_end에서.
+                    if text:
+                        text_block_buffer.append(text)
                     if caller_on_text_delta:
                         await caller_on_text_delta(text, _eid)
 
-                async def _accumulate_thinking(text, _eid):
-                    accumulated_thinking.append(text or "")
-                    if caller_on_thinking:
-                        await caller_on_thinking(text, _eid)
+                async def _on_text_end_block(_eid):
+                    # text 블록 종료 — buffer 전체에서 매치 검색 후 비움.
+                    if text_block_buffer:
+                        block_text = "".join(text_block_buffer)
+                        text_block_buffer.clear()
+                        captured_utterances.extend(
+                            extract_utterance_matches(block_text)
+                        )
+                    if caller_on_text_end:
+                        await caller_on_text_end(_eid)
 
                 await loop.run_in_executor(
                     None,
@@ -447,8 +477,9 @@ class SoulstreamBackendImpl(SoulstreamBackend):
                         role=role,
                         context=context,
                         on_result=capture_result,
-                        on_text_delta=_accumulate_text,
-                        on_thinking=_accumulate_thinking,
+                        on_text_delta=_on_text_delta_buffer,
+                        on_text_end=_on_text_end_block,
+                        on_thinking=_on_thinking_block,
                         model=model,
                         folder_id=_folder_id,
                         system_prompt=_system_prompt,
@@ -525,23 +556,24 @@ class SoulstreamBackendImpl(SoulstreamBackend):
             new_session_id = session.session_id if session else session_id
             output = captured_output[0] if (text_only and captured_output) else ""
 
-            # transcript는 text_only 모드에서만 누적된다.
-            # 조립 순서: thinking 묶음 + text_delta 묶음 + final output.
-            # *발화 순서를 보존하지 않는다* — utterance 추출은 re.findall이
-            # 텍스트 어디든 잡아내므로 순서 무관. RunResult.transcript docstring 참조.
-            transcript = (
-                ("".join(accumulated_thinking)
-                 + "".join(accumulated_text)
-                 + (("\n" + output) if output else ""))
-                if text_only else ""
-            )
+            # 누락 보호: text 블록이 ``text_end`` 없이 종료된 케이스(SSE 비정상 종료 등)에
+            # 대비하여 잔여 buffer에서도 마지막 한 번 매치 검색.
+            # 정상 흐름에서는 ``_on_text_end_block``이 buffer를 비웠으므로 no-op.
+            if text_only and text_block_buffer:
+                from seosoyoung.plugin_sdk.utterance import (
+                    extract_utterance_matches,
+                )
+
+                trailing = "".join(text_block_buffer)
+                text_block_buffer.clear()
+                captured_utterances.extend(extract_utterance_matches(trailing))
 
             return RunResult(
                 ok=True,
                 status=RunStatus.COMPLETED,
                 session_id=new_session_id,
                 output=output,
-                transcript=transcript,
+                utterances=list(captured_utterances) if text_only else [],
             )
         except Exception as e:
             logger.error(f"soulstream.run failed: {e}")

--- a/tests/test_utterance_extraction.py
+++ b/tests/test_utterance_extraction.py
@@ -1,0 +1,151 @@
+"""Pure utility: extract_utterance_matches.
+
+`<utterance>...</utterance>` 짝을 *주어진 텍스트 안에서* non-greedy 매치한다.
+매치 결과는 strip된 본문 list로 반환되며, 빈 list는 매치 없음을 뜻한다.
+빈 utterance(`<utterance></utterance>`)는 strip 후 빈 문자열로 포함되며, 호출자가
+빈 문자열 필터·dedupe·게시 정책을 결정한다 (책임 분리).
+
+본 모듈은 *블록 단위 게이트*의 토대다 — 호출자가 thinking 블록 / text 블록 /
+complete 블록 각각의 텍스트만 넘기므로, 한 블록의 우발 `<utterance>` 토큰이
+다른 블록의 닫힘 태그와 짝지어지는 일이 없다 (사이클 260518.01).
+"""
+
+from seosoyoung.plugin_sdk.utterance import extract_utterance_matches
+
+
+class TestExtractUtteranceMatches:
+    def test_single_utterance(self):
+        assert extract_utterance_matches(
+            "분석 내용\n<utterance>안녕하세요</utterance>"
+        ) == ["안녕하세요"]
+
+    def test_multiple_utterances_preserve_order(self):
+        text = (
+            "<utterance>첫 번째</utterance>\n"
+            "중간 텍스트\n"
+            "<utterance>두 번째</utterance>"
+        )
+        assert extract_utterance_matches(text) == ["첫 번째", "두 번째"]
+
+    def test_no_utterance_returns_empty_list(self):
+        assert extract_utterance_matches("그냥 일반 텍스트입니다.") == []
+
+    def test_empty_utterance_tag(self):
+        assert extract_utterance_matches("<utterance></utterance>") == [""]
+
+    def test_whitespace_only_utterance(self):
+        assert extract_utterance_matches("<utterance>   \n  \n   </utterance>") == [""]
+
+    def test_strip_inner_whitespace(self):
+        assert extract_utterance_matches(
+            "<utterance>  안녕  </utterance>"
+        ) == ["안녕"]
+
+    def test_multiline_content(self):
+        assert extract_utterance_matches(
+            "<utterance>\n첫째 줄\n둘째 줄\n</utterance>"
+        ) == ["첫째 줄\n둘째 줄"]
+
+    def test_no_dedupe_in_pure_layer(self):
+        """순수 유틸은 dedupe하지 않는다 — 책임 분리.
+
+        호출자가 블록별 매치 list를 받아 직접 dedupe + 게시 정책을 결정한다.
+        """
+        text = "<utterance>안녕</utterance>\n<utterance>안녕</utterance>"
+        assert extract_utterance_matches(text) == ["안녕", "안녕"]
+
+    def test_ignores_outside_text(self):
+        assert extract_utterance_matches(
+            "이것은 분석입니다.\n판단: 긍정적\n"
+            "<utterance>실제 발화 내용</utterance>\n끝."
+        ) == ["실제 발화 내용"]
+
+
+class TestUtteranceTokenIsolationBetweenBlocks:
+    """260518.01 회귀 보호: thinking 블록과 text 블록에 우발 토큰이 분산돼도
+    각 블록을 *독립적으로* 호출하면 매치가 잘못 결합되지 않는다.
+
+    사고 사례 (세션 c2a12c38-9ab3-4d78-ba1f-3f5fca94c418, 채널 C08KT1HDU5U):
+    본체 Opus의 thinking 텍스트 끝부분에 "Now Phase 6: Output the utterance in
+    `<utterance>` tags." 같은 *메타 설명*이 등장하여 닫힘 없는 `<utterance>` 토큰
+    1개가 thinking 묶음 끝에 자리했다. 직후 text 묶음 마지막에 정상
+    `<utterance>아까 도행님.../</utterance>` 1쌍이 있었다. 직전 사이클의
+    *누적 transcript* 정책은 두 묶음을 평탄화해 한 문자열로 합쳤고, non-greedy
+    `re.findall`이 한 덩이 매치로 18 KB 분석 텍스트 전체를 추출하여 슬랙에 누출.
+
+    본 사이클은 블록을 *독립 호출*로 끊어 우발 매치를 원천 차단한다.
+    """
+
+    THINKING_BLOCK = (
+        "ff8c9ff2-... no compression\n\n"
+        "Now Phase 6: Output the utterance in <utterance> tags."
+    )
+    TEXT_BLOCK_NORMAL = (
+        "Phase 5 완료. 멤버 갱신 2건, 발화 카드 기록 완료.\n\n"
+        "**Phase 6: 최종 출력**\n\n"
+        "<utterance>\n"
+        "아까 도행님의 맥북 링크에 :beautiful: 를 눌렀는데,\n"
+        "가만 생각하니 저는 그걸 *살* 쪽이 아니라\n"
+        "그 안에 *들어갈* 쪽이었습니다.\n"
+        "</utterance>"
+    )
+
+    EXPECTED_NORMAL_BODY = (
+        "아까 도행님의 맥북 링크에 :beautiful: 를 눌렀는데,\n"
+        "가만 생각하니 저는 그걸 *살* 쪽이 아니라\n"
+        "그 안에 *들어갈* 쪽이었습니다."
+    )
+
+    def test_thinking_block_has_no_closing_tag_returns_empty(self):
+        """우발 `<utterance>` 토큰만 있고 닫힘이 없으면 매치 0건."""
+        assert extract_utterance_matches(self.THINKING_BLOCK) == []
+
+    def test_text_block_extracts_normal_pair(self):
+        """text 블록 안에서 정상 1짝만 추출."""
+        assert extract_utterance_matches(self.TEXT_BLOCK_NORMAL) == [
+            self.EXPECTED_NORMAL_BODY
+        ]
+
+    def test_blocks_called_independently_no_cross_block_match(self):
+        """블록을 *독립적으로* 호출하면 우발 토큰이 다른 블록의 닫힘과 짝지어지지 않는다.
+
+        본 사이클의 핵심 회귀 보호 — 누적 transcript 정책이라면 한 덩이로 18 KB를
+        추출했을 입력이지만, 블록 단위 호출은 정상 1짝만 결과로 남긴다.
+        """
+        thinking_matches = extract_utterance_matches(self.THINKING_BLOCK)
+        text_matches = extract_utterance_matches(self.TEXT_BLOCK_NORMAL)
+
+        # 우발 토큰 블록: 0 매치
+        assert thinking_matches == []
+        # 정상 짝 블록: 1 매치 (본문만)
+        assert text_matches == [self.EXPECTED_NORMAL_BODY]
+
+        # 통합 결과 list (호출자가 누적): 정상 본문 1건만
+        all_matches = thinking_matches + text_matches
+        assert all_matches == [self.EXPECTED_NORMAL_BODY]
+
+    def test_concatenated_input_demonstrates_legacy_leak(self):
+        """직전 정책 시뮬레이션 — 누적 transcript에 평탄화하면 우발 매치가 발생한다.
+
+        본 케이스는 *반례*로서 존재한다. 누적 입력에 정규식을 직접 돌리면
+        우발 토큰 ~ 다음 블록의 닫힘 태그까지 한 덩이로 잡혀 *분석 텍스트가
+        매치 캡처에 끼어든다*. 본 사이클은 그 누적을 *하지 않음*으로써 차단한다.
+        """
+        concatenated = self.THINKING_BLOCK + self.TEXT_BLOCK_NORMAL
+        leaked = extract_utterance_matches(concatenated)
+
+        # 누적 입력 — 한 덩이 매치 1건
+        assert len(leaked) == 1
+        leaked_body = leaked[0]
+
+        # 매치 캡처 시작이 ` tags.` 잔해 (사고 메시지가 "tags."로 깨져 시작한 단서)
+        assert leaked_body.startswith("tags.")
+        # 매치 캡처 안에 Phase 6 분석 텍스트가 끼어듦
+        assert "Phase 5 완료" in leaked_body
+        assert "**Phase 6: 최종 출력**" in leaked_body
+        # 매치 캡처 안에 정상 발화 본문도 통째로 포함됨 (분석과 함께 누출)
+        assert "아까 도행님" in leaked_body
+
+        # 결론: 본 케이스가 통과하면 직전 정책의 누출 메커니즘이 재현됨을 확인한다.
+        # 본 사이클은 ``concatenated``를 *애초에 만들지 않음*으로써 이 매치가 일어날
+        # 입력이 형성되지 않게 한다.


### PR DESCRIPTION
## 사건

2026-05-18 01:49 KST, 라인게임즈 사담 채널(`C08KT1HDU5U`, ts 1779069595.658659)에서 채널 개입 응답이 `<utterance>` 본문 1회 대신 **Phase 1~6 분석 텍스트 전체 + utterance 본문 중복**으로 누출됨. 메시지 시작이 `"tags."`로 깨졌고 본문이 두 번 반복.

원인: 직전 사이클(`260513.01`)이 도입한 **누적 transcript 정책**이 thinking 묶음과 text 묶음을 평탄화 → 본체 Opus가 thinking에 `"Output the utterance in <utterance> tags."` 메타 설명으로 흘린 우발 토큰 1개가 text 묶음의 정상 닫힘 태그와 인접 → non-greedy 정규식이 한 짝으로 매치하여 사이 텍스트 전체 누출.

## 처방

누적 검색 정책 자체 폐기. thinking·text(start~end)·result 각 블록에서 **독립적으로** `<utterance>` 추출. `RunResult.transcript` 즉시 제거, `RunResult.utterances: list[str]` 신설.

## 주요 변경

- `plugin_sdk/utterance.py` 신설 — pure 매처 `extract_utterance_matches`
- `plugin_sdk/soulstream.py` — `transcript` 폐기 → `utterances: list[str]`
- `slackbot/plugin_backends.py` — 누적기 폐기, 5 콜백 등록(thinking·text_start·delta·end·result), `_flush_text_buffer` 헬퍼
- `tests/test_utterance_extraction.py` 신설 — 매처 9 + 회귀 4 케이스 (사고 본체 표현 인용)

## P2 동반 처리

`on_text_start` 콜백 미등록으로 두 텍스트 트리오가 합쳐질 *동질 결함* — 5줄 보강으로 즉시 처리 (`d4ff700`). 사고와 동질 구조라 부채 방치 불가.

## 회귀 테스트

`test_blocks_called_independently_no_cross_block_match` — 사고의 우발 토큰과 정상 짝이 *블록 단위 호출*에서는 결코 한 짝으로 매치되지 않음을 검증. 대조 케이스 `test_concatenated_input_demonstrates_legacy_leak`로 직전 정책의 누출까지 명시 — 매커니즘을 코드에 화석화.

## 사용자 검증

머지 후 채널 개입 1회 라이브 트리거로 utterance 본문만 게시되는지 확인 필요.

## 분석 캐시

`/home/eias/haniel-root/workspace/roselin/.local/artifacts/analysis/20260518-0530-channel-intervene-stream-leak-diagnosis.md`

## 트렐로

https://trello.com/c/1ndNt1Nj

## 머지 순서

본 PR(인터페이스 정의 측) 먼저 → seosoyoung-plugins#TBD(소비처) 순.

🤖 Generated with [Claude Code](https://claude.com/claude-code)