### PR TITLE
fix: restore persistent listener context

### DIFF
--- a/src/seosoyoung/slackbot/soulstream/executor.py
+++ b/src/seosoyoung/slackbot/soulstream/executor.py
@@ -209,6 +209,7 @@ class ClaudeExecutor:
                 on_input_request_responded=on_input_request_responded,
                 on_input_request_expired=on_input_request_expired,
                 caller_info=caller_info,
+                context=context,
             )
             return
 
@@ -265,17 +266,12 @@ class ClaudeExecutor:
         on_input_request_responded=None,
         on_input_request_expired=None,
         caller_info: Optional[dict] = None,
+        context: Optional[list] = None,
     ):
         """인터벤션 처리: 실행 중인 스레드에 새 메시지가 도착한 경우
 
         Soulstream에 interrupt를 전송하여 현재 실행을 중단시킵니다.
         Soulstream 측에서 interrupt를 받으면 새 프롬프트로 이어서 실행합니다.
-
-        알려진 제한: context(structured context items)는 이 경로에서 전달되지 않는다.
-        인터벤션은 fire_interrupt_remote → pending_session_interventions 큐 경로를 통해
-        처리되는데, 이 큐가 context를 함께 저장하는 메커니즘이 없다.
-        따라서 인터벤션이 flush되어 실행될 때 context 없이 프롬프트만 전달된다.
-        이 제한은 인터벤션 기능 전체의 리팩터링 시 별도로 해결한다.
 
         F-9 fix(2026-05-08): caller_info를 fire_interrupt_remote에 forward하여
         2차+ 메시지의 발신자 신원이 InterventionSentEvent.caller_info까지 운반되도록 한다.
@@ -289,6 +285,7 @@ class ClaudeExecutor:
             pending_session_interventions=self._pending_session_interventions,
             pending_session_lock=self._pending_session_lock,
             caller_info=caller_info,
+            context_items=context,
         )
 
     def _run_with_lock(
@@ -471,14 +468,18 @@ class ClaudeExecutor:
         if pending:
             adapter = self._get_service_adapter()
             # F-9 fix(2026-05-08): tuple 형식이 (prompt, user)에서 (prompt, user, caller_info)로
-            # 확장됐다 (intervention.py:fire_interrupt_remote가 caller_info도 저장).
+            # 확장됐다. Persistent SSE hotfix: context_items까지 함께 저장한다.
             # 구버전 2-tuple(메모리에 남아있던 데이터 등)도 graceful 처리.
             for entry in pending:
-                if len(entry) == 3:
+                if len(entry) == 4:
+                    pending_prompt, pending_user, pending_caller_info, pending_context_items = entry
+                elif len(entry) == 3:
                     pending_prompt, pending_user, pending_caller_info = entry
+                    pending_context_items = None
                 else:
                     pending_prompt, pending_user = entry
                     pending_caller_info = None
+                    pending_context_items = None
                 try:
                     from seosoyoung.utils.async_bridge import run_in_new_loop as _run
                     _run(adapter.intervene(
@@ -486,6 +487,7 @@ class ClaudeExecutor:
                         text=pending_prompt,
                         user=pending_user,
                         caller_info=pending_caller_info,
+                        context_items=pending_context_items,
                     ))
                     logger.info(f"[Remote] 버퍼된 인터벤션 flush: thread={thread_ts}, session={session_id}")
                 except Exception as e:

--- a/src/seosoyoung/slackbot/soulstream/intervention.py
+++ b/src/seosoyoung/slackbot/soulstream/intervention.py
@@ -29,6 +29,7 @@ class InterventionManager:
         pending_session_interventions: Optional[dict] = None,
         pending_session_lock: Optional[Any] = None,
         caller_info: Optional[dict] = None,
+        context_items: Optional[list] = None,
     ):
         """Soulstream에 HTTP intervene 요청 (agent_session_id 기반)
 
@@ -40,6 +41,7 @@ class InterventionManager:
 
         F-9 fix(2026-05-08): caller_info를 service_adapter.intervene에 forward하고,
         버퍼 보관 시에도 함께 저장하여 session_id 확보 후 flush될 때 운반되도록 한다.
+        Persistent SSE hotfix: 파일 첨부 등 context_items도 같은 경로로 운반한다.
         이로 인해 슬랙 2차+ 메시지가 InterventionSentEvent.caller_info를 wire에 박아
         unified-dashboard·soul-app에서 발신자(슬랙)의 아바타·이름이 표시된다.
         """
@@ -54,6 +56,7 @@ class InterventionManager:
                         text=prompt,
                         user="intervention",
                         caller_info=caller_info,
+                        context_items=context_items,
                     )
                 )
                 logger.info(f"[Remote] 인터벤션 전송 완료: thread={thread_ts}, session={session_id}")
@@ -62,13 +65,13 @@ class InterventionManager:
                 logger.warning(f"[Remote] 인터벤션 전송 실패: thread={thread_ts}, {e}")
                 return
 
-        # 2. session_id 미확보 → 버퍼에 보관 (caller_info도 함께)
+        # 2. session_id 미확보 → 버퍼에 보관 (caller_info/context_items도 함께)
         if pending_session_interventions is not None and pending_session_lock is not None:
             with pending_session_lock:
                 if thread_ts not in pending_session_interventions:
                     pending_session_interventions[thread_ts] = []
                 pending_session_interventions[thread_ts].append(
-                    (prompt, "intervention", caller_info)
+                    (prompt, "intervention", caller_info, context_items)
                 )
             logger.info(f"[Remote] 인터벤션 버퍼에 보관 (session_id 미확보): thread={thread_ts}")
             return

--- a/src/seosoyoung/slackbot/soulstream/service_adapter.py
+++ b/src/seosoyoung/slackbot/soulstream/service_adapter.py
@@ -178,6 +178,7 @@ class ClaudeServiceAdapter:
         *,
         attachment_paths: Optional[List[str]] = None,
         caller_info: Optional[dict] = None,
+        context_items: Optional[list] = None,
     ) -> bool:
         """세션에 인터벤션 전송 (agent_session_id 기반)
 
@@ -194,6 +195,7 @@ class ClaudeServiceAdapter:
                 user=user,
                 attachment_paths=attachment_paths,
                 caller_info=caller_info,
+                context_items=context_items,
             )
             logger.info(f"[Remote] 인터벤션 전송 완료: session={agent_session_id}")
             return True

--- a/src/seosoyoung/slackbot/soulstream/service_client.py
+++ b/src/seosoyoung/slackbot/soulstream/service_client.py
@@ -530,6 +530,7 @@ class SoulServiceClient:
         *,
         attachment_paths: Optional[List[str]] = None,
         caller_info: Optional[dict] = None,
+        context_items: Optional[List[dict]] = None,
     ) -> dict:
         """세션에 개입 메시지 전송
 
@@ -549,6 +550,8 @@ class SoulServiceClient:
             data["attachment_paths"] = attachment_paths
         if caller_info:
             data["caller_info"] = caller_info
+        if context_items:
+            data["context_items"] = context_items
 
         async with session.post(url, json=data) as response:
             if response.status == 202:
@@ -911,7 +914,7 @@ class SoulServiceClient:
                 elif event.event == "thinking":
                     if on_thinking:
                         await on_thinking(
-                            event.data.get("thinking", ""),
+                            event.data.get("thinking") or event.data.get("text", ""),
                             eid,
                         )
 

--- a/tests/core/test_intervention.py
+++ b/tests/core/test_intervention.py
@@ -107,9 +107,13 @@ class TestInterventionHandling:
                     user_message=None,
                     on_result=None,
                     session_id="session_abc",
+                    context=[{"key": "attachments", "content": "파일: map.png"}],
                 )
 
         mock_fire.assert_called_once()
+        assert mock_fire.call_args.kwargs["context_items"] == [
+            {"key": "attachments", "content": "파일: map.png"},
+        ]
 
 
 class TestInterventionViaRun:
@@ -135,12 +139,16 @@ class TestInterventionViaRun:
                     msg_ts="msg_456",
                     on_compact=_noop_compact,
                     presentation=pctx,
+                    context=[{"key": "attachments", "content": "파일: map.png"}],
                 )
 
         # say는 호출되지 않아야 함
         say.assert_not_called()
         # fire_interrupt_remote가 호출됨
         mock_fire.assert_called_once()
+        assert mock_fire.call_args.kwargs["context_items"] == [
+            {"key": "attachments", "content": "파일: map.png"},
+        ]
 
 
 class TestInterruptedExecution:

--- a/tests/core/test_session_intervention.py
+++ b/tests/core/test_session_intervention.py
@@ -164,9 +164,17 @@ class TestInterventionRemoteSessionBased:
                 prompt="새 질문",
                 service_adapter=adapter,
                 session_id="sess-abc",
+                context_items=[{"key": "attachments", "content": "파일: map.png"}],
             )
 
         mock_run.assert_called_once()
+        adapter.intervene.assert_called_once_with(
+            agent_session_id="sess-abc",
+            text="새 질문",
+            user="intervention",
+            caller_info=None,
+            context_items=[{"key": "attachments", "content": "파일: map.png"}],
+        )
 
     def test_fire_interrupt_remote_without_session_id_buffers(self):
         """session_id 미확보 시 버퍼에 보관"""
@@ -182,11 +190,15 @@ class TestInterventionRemoteSessionBased:
             session_id=None,
             pending_session_interventions=pending,
             pending_session_lock=lock,
+            context_items=[{"key": "attachments", "content": "파일: map.png"}],
         )
 
         assert "thread_123" in pending
         assert len(pending["thread_123"]) == 1
-        assert pending["thread_123"][0] == ("새 질문", "intervention", None)
+        assert pending["thread_123"][0] == (
+            "새 질문", "intervention", None,
+            [{"key": "attachments", "content": "파일: map.png"}],
+        )
 
     def test_fire_interrupt_remote_fallback_without_buffer(self):
         """버퍼 없이 session_id도 없으면 경고만 로깅"""

--- a/tests/handlers/test_thread_mention.py
+++ b/tests/handlers/test_thread_mention.py
@@ -122,6 +122,14 @@ class TestProcessThreadMessage:
 
         assert result is True
         run_claude.assert_called_once()
+        context_items = run_claude.call_args.kwargs["context"]
+        attachment_items = [
+            item for item in context_items
+            if item.get("key") == "attachments"
+        ]
+        assert len(attachment_items) == 1
+        assert "test.txt" in attachment_items[0]["content"]
+        assert "hello" in attachment_items[0]["content"]
 
     def test_user_info_failure(self):
         """사용자 정보 조회 실패 시 에러 메시지"""

--- a/tests/soulstream/test_service_adapter.py
+++ b/tests/soulstream/test_service_adapter.py
@@ -282,6 +282,7 @@ class TestIntervene:
             user="user1",
             attachment_paths=None,
             caller_info=None,
+            context_items=None,
         )
 
     @pytest.mark.asyncio
@@ -307,6 +308,32 @@ class TestIntervene:
             user="U123",
             attachment_paths=None,
             caller_info=ci,
+            context_items=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_intervene_with_context_items(self, adapter, mock_client):
+        """파일 첨부 context_items를 service_client.intervene까지 forward."""
+        mock_client.intervene.return_value = {"queued": True}
+        context_items = [
+            {"key": "attachments", "label": "첨부 파일", "content": "파일: map.png"},
+        ]
+
+        result = await adapter.intervene(
+            agent_session_id="sess-abc",
+            text="파일 확인",
+            user="U123",
+            context_items=context_items,
+        )
+
+        assert result is True
+        mock_client.intervene.assert_awaited_once_with(
+            agent_session_id="sess-abc",
+            text="파일 확인",
+            user="U123",
+            attachment_paths=None,
+            caller_info=None,
+            context_items=context_items,
         )
 
     @pytest.mark.asyncio

--- a/tests/soulstream/test_service_client.py
+++ b/tests/soulstream/test_service_client.py
@@ -437,6 +437,27 @@ class TestSoulServiceClientIntervene:
         assert body["attachment_paths"] == ["/path/to/file.png"]
 
     @pytest.mark.asyncio
+    async def test_intervene_with_context_items(self, client):
+        """context_items 포함 전송"""
+        mock_response = AsyncMock()
+        mock_response.status = 202
+        mock_response.json = AsyncMock(return_value={"queued": True})
+        session = _mock_session(mock_response)
+        client._session = session
+        context_items = [
+            {"key": "attachments", "label": "첨부 파일", "content": "파일: map.png"},
+        ]
+
+        await client.intervene(
+            "sess-123", "look at this", "user1",
+            context_items=context_items,
+        )
+
+        call_kwargs = session.post.call_args
+        body = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+        assert body["context_items"] == context_items
+
+    @pytest.mark.asyncio
     async def test_intervene_not_found(self, client):
         """404 응답 시 SessionNotFoundError"""
         mock_response = MagicMock()
@@ -961,6 +982,33 @@ class TestHandleSSEEvents:
         assert history_events == [{"last_event_id": 42}]
         assert user_events == [{"text": "from web", "caller_info": {"source": "browser"}}]
         assert intervention_events == [{"text": "from app", "callerInfo": {"source": "soul-app"}}]
+
+    @pytest.mark.asyncio
+    async def test_thinking_event_accepts_codex_text_payload(self, client):
+        """Codex app-server thinking payload의 text 키도 thinking 콜백으로 전달한다."""
+        sse_data = (
+            b"event:init\n"
+            b'data:{"agentSessionId":"sess-orch-123"}\n'
+            b"\n"
+            b"event:thinking\n"
+            b'id:12\n'
+            b'data:{"text":"checking files"}\n'
+            b"\n"
+        )
+        mock_response = AsyncMock()
+        mock_response.content = _make_stream_reader(sse_data)
+        thinking_events = []
+
+        async def on_thinking(text, event_id):
+            thinking_events.append((text, event_id))
+
+        result = await client._handle_sse_events(
+            mock_response,
+            on_thinking=on_thinking,
+        )
+
+        assert result.success is True
+        assert thinking_events == [("checking files", 12)]
 
     @pytest.mark.asyncio
     async def test_listen_session_events_uses_after_id(self, client):

--- a/tests/soulstream/test_session_listener.py
+++ b/tests/soulstream/test_session_listener.py
@@ -130,6 +130,47 @@ async def test_external_user_event_survives_marker_post_failure():
 
 
 @pytest.mark.asyncio
+async def test_external_turn_posts_thinking_and_updates_tool_message_in_place():
+    manager = PersistentSessionListenerManager(client_factory=MagicMock())
+    slack_client = MagicMock()
+    slack_client.chat_postMessage.side_effect = [
+        {"ts": "marker-ts"},
+        {"ts": "thinking-ts"},
+        {"ts": "tool-ts"},
+    ]
+    state = manager._create_state(
+        "sess-1", channel="C123", thread_ts="1000.0001", slack_client=slack_client,
+    )
+
+    await manager._handle_external_input(
+        state,
+        {
+            "text": "웹 입력",
+            "caller_info": {"source": "browser", "display_name": "Jubok Kim"},
+        },
+    )
+    await manager._dispatch_current(state, "on_thinking", "검토 중", 101)
+    await manager._dispatch_current(
+        state, "on_tool_start", "Read", {"file_path": "/tmp/a.txt"}, "toolu-1", 102,
+    )
+    await manager._dispatch_current(
+        state, "on_tool_result", "file contents", "toolu-1", False, 103,
+    )
+
+    assert slack_client.chat_postMessage.call_count == 3
+    thinking_call = slack_client.chat_postMessage.call_args_list[1].kwargs
+    tool_call = slack_client.chat_postMessage.call_args_list[2].kwargs
+    assert thinking_call["thread_ts"] == "1000.0001"
+    assert "검토 중" in thinking_call["text"]
+    assert tool_call["thread_ts"] == "1000.0001"
+    assert "Read" in tool_call["text"]
+    slack_client.chat_update.assert_called_once()
+    update_call = slack_client.chat_update.call_args.kwargs
+    assert update_call["ts"] == "tool-ts"
+    assert "file contents" in update_call["text"]
+
+
+@pytest.mark.asyncio
 async def test_slack_origin_event_does_not_echo_but_resets_activity():
     now = [100.0]
     manager = PersistentSessionListenerManager(


### PR DESCRIPTION
## Summary

Persistent SSE hotfix for regressions found after PR #16.

- Accept Codex/app-server `thinking` SSE payloads that use `text`, so external-session responses show thinking in Slack.
- Preserve Slack file attachment `context_items` through running intervention paths in the bot client/adapter.
- Add regression coverage that external turns reuse the same presentation callback set, so tool messages update in place instead of splitting per SSE event.
- Strengthen Slack file attachment handler coverage to assert attachment context reaches executor calls.

## Defect Mapping

- Defect 2: Slack file attachment context is present in executor `context` and forwarded through `intervene` paths.
- Defect 3: External response thinking events are displayed from `thinking` or `text` payloads.
- Defect 4: External response tool updates stay on the same Slack message.

Defect 1 and the orch-side root of Defect 2 are fixed in the companion soulstream PR.

## Tests

- `.venv/bin/python -m pytest --timeout=60 -q`
- `git diff --check`
