### PR TITLE
외부 세션 listener 표시 모드 clean 통일

### DIFF
--- a/src/seosoyoung/slackbot/presentation/session_listener.py
+++ b/src/seosoyoung/slackbot/presentation/session_listener.py
@@ -10,8 +10,12 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
+from seosoyoung.slackbot.presentation.activity_board import ActivityBoard, BOARD_EMPTY_TEXT
 from seosoyoung.slackbot.presentation.node_map import SlackNodeMap
-from seosoyoung.slackbot.presentation.progress import build_event_callbacks
+from seosoyoung.slackbot.presentation.progress import (
+    build_event_callbacks,
+    post_initial_placeholder,
+)
 from seosoyoung.slackbot.presentation.session_events import (
     is_slack_origin_event,
     post_external_user_message,
@@ -257,6 +261,22 @@ class PersistentSessionListenerManager:
             await callbacks["cleanup"]()
 
     def _build_turn_callbacks(self, state: _ListenerState) -> dict[str, Callable]:
+        placeholder_ts = post_initial_placeholder(
+            state.slack_client,
+            state.channel,
+            state.thread_ts,
+        )
+        board = None
+        try:
+            reply = state.slack_client.chat_postMessage(
+                channel=state.channel,
+                thread_ts=state.thread_ts,
+                text=BOARD_EMPTY_TEXT,
+            )
+            board = ActivityBoard(state.slack_client, state.channel, reply["ts"])
+        except Exception as exc:
+            logger.warning("[SSE:listener] placeholder B 게시 실패: %s", exc)
+
         pctx = PresentationContext(
             channel=state.channel,
             thread_ts=state.thread_ts,
@@ -268,7 +288,13 @@ class PersistentSessionListenerManager:
             is_existing_thread=True,
             is_thread_reply=True,
         )
-        return build_event_callbacks(pctx, SlackNodeMap(), mode="keep")
+        return build_event_callbacks(
+            pctx,
+            SlackNodeMap(),
+            mode="clean",
+            initial_placeholder_ts=placeholder_ts,
+            initial_board=board,
+        )
 
     async def _dispatch_current(
         self,

--- a/tests/soulstream/test_session_listener.py
+++ b/tests/soulstream/test_session_listener.py
@@ -1,10 +1,11 @@
 """Slack thread persistent session event listener 테스트."""
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
+from seosoyoung.slackbot.presentation.activity_board import BOARD_EMPTY_TEXT
 from seosoyoung.slackbot.presentation.session_listener import (
     DEFAULT_INACTIVITY_TIMEOUT_SECONDS,
     PersistentSessionListenerManager,
@@ -102,7 +103,8 @@ async def test_external_user_event_posts_marker_and_resets_activity():
 
     assert state.last_input_at == 150.0
     assert state.current_callbacks is not None
-    slack_client.chat_postMessage.assert_called_once_with(
+    assert slack_client.chat_postMessage.call_count == 3
+    slack_client.chat_postMessage.assert_any_call(
         channel="C123",
         thread_ts="1000.0001",
         text="[웹] Jubok Kim: 웹 입력",
@@ -130,13 +132,15 @@ async def test_external_user_event_survives_marker_post_failure():
 
 
 @pytest.mark.asyncio
-async def test_external_turn_posts_thinking_and_updates_tool_message_in_place():
+@patch("seosoyoung.slackbot.presentation.progress._event_delete_delay", return_value=3600)
+@patch("seosoyoung.slackbot.presentation.progress._thinking_delete_delay", return_value=3600)
+async def test_external_turn_uses_activity_board_clean_mode(_thinking_delay, _event_delay):
     manager = PersistentSessionListenerManager(client_factory=MagicMock())
     slack_client = MagicMock()
     slack_client.chat_postMessage.side_effect = [
         {"ts": "marker-ts"},
-        {"ts": "thinking-ts"},
-        {"ts": "tool-ts"},
+        {"ts": "placeholder-a-ts"},
+        {"ts": "board-ts"},
     ]
     state = manager._create_state(
         "sess-1", channel="C123", thread_ts="1000.0001", slack_client=slack_client,
@@ -158,16 +162,117 @@ async def test_external_turn_posts_thinking_and_updates_tool_message_in_place():
     )
 
     assert slack_client.chat_postMessage.call_count == 3
-    thinking_call = slack_client.chat_postMessage.call_args_list[1].kwargs
-    tool_call = slack_client.chat_postMessage.call_args_list[2].kwargs
-    assert thinking_call["thread_ts"] == "1000.0001"
-    assert "검토 중" in thinking_call["text"]
-    assert tool_call["thread_ts"] == "1000.0001"
-    assert "Read" in tool_call["text"]
-    slack_client.chat_update.assert_called_once()
-    update_call = slack_client.chat_update.call_args.kwargs
-    assert update_call["ts"] == "tool-ts"
-    assert "file contents" in update_call["text"]
+    board_post = slack_client.chat_postMessage.call_args_list[2].kwargs
+    assert board_post == {
+        "channel": "C123",
+        "thread_ts": "1000.0001",
+        "text": BOARD_EMPTY_TEXT,
+    }
+    assert slack_client.chat_update.call_count == 3
+    assert all(c.kwargs["ts"] == "board-ts" for c in slack_client.chat_update.call_args_list)
+    rendered_updates = "\n".join(c.kwargs["text"] for c in slack_client.chat_update.call_args_list)
+    assert "검토 중" in rendered_updates
+    assert "Read" in rendered_updates
+    assert "file contents" in rendered_updates
+
+    await manager._handle_complete(state, {})
+
+    slack_client.chat_delete.assert_has_calls([
+        call(channel="C123", ts="placeholder-a-ts"),
+        call(channel="C123", ts="board-ts"),
+    ])
+
+
+def test_build_turn_callbacks_passes_clean_mode_placeholders():
+    manager = PersistentSessionListenerManager(client_factory=MagicMock())
+    slack_client = MagicMock()
+    slack_client.chat_postMessage.return_value = {"ts": "board-ts"}
+    state = manager._create_state(
+        "sess-1", channel="C123", thread_ts="1000.0001", slack_client=slack_client,
+    )
+    expected_callbacks = {"cleanup": AsyncMock()}
+    board = MagicMock(name="board")
+
+    with (
+        patch(
+            "seosoyoung.slackbot.presentation.session_listener.post_initial_placeholder",
+            return_value="placeholder-a-ts",
+        ) as mock_post_placeholder,
+        patch(
+            "seosoyoung.slackbot.presentation.session_listener.ActivityBoard",
+            return_value=board,
+        ) as mock_board_cls,
+        patch(
+            "seosoyoung.slackbot.presentation.session_listener.build_event_callbacks",
+            return_value=expected_callbacks,
+        ) as mock_build_callbacks,
+    ):
+        callbacks = manager._build_turn_callbacks(state)
+
+    assert callbacks is expected_callbacks
+    mock_post_placeholder.assert_called_once_with(slack_client, "C123", "1000.0001")
+    slack_client.chat_postMessage.assert_called_once_with(
+        channel="C123",
+        thread_ts="1000.0001",
+        text=BOARD_EMPTY_TEXT,
+    )
+    mock_board_cls.assert_called_once_with(slack_client, "C123", "board-ts")
+    call_args = mock_build_callbacks.call_args
+    assert call_args.args[1].__class__.__name__ == "SlackNodeMap"
+    assert call_args.kwargs["mode"] == "clean"
+    assert call_args.kwargs["initial_placeholder_ts"] == "placeholder-a-ts"
+    assert call_args.kwargs["initial_board"] is board
+
+
+@pytest.mark.asyncio
+@patch("seosoyoung.slackbot.presentation.progress._thinking_delete_delay", return_value=3600)
+async def test_external_turn_cleanup_isolated_per_turn(_thinking_delay):
+    manager = PersistentSessionListenerManager(client_factory=MagicMock())
+    slack_client = MagicMock()
+    slack_client.chat_postMessage.side_effect = [
+        {"ts": "marker-1"},
+        {"ts": "placeholder-a-1"},
+        {"ts": "board-1"},
+        {"ts": "marker-2"},
+        {"ts": "placeholder-a-2"},
+        {"ts": "board-2"},
+    ]
+    state = manager._create_state(
+        "sess-1", channel="C123", thread_ts="1000.0001", slack_client=slack_client,
+    )
+
+    await manager._handle_external_input(
+        state,
+        {
+            "text": "첫 번째 웹 입력",
+            "caller_info": {"source": "browser", "display_name": "Jubok Kim"},
+        },
+    )
+    await manager._dispatch_current(state, "on_thinking", "첫 번째 검토", 101)
+    await manager._handle_complete(state, {})
+
+    slack_client.chat_delete.assert_has_calls([
+        call(channel="C123", ts="placeholder-a-1"),
+        call(channel="C123", ts="board-1"),
+    ])
+    first_turn_delete_count = slack_client.chat_delete.call_count
+
+    await manager._handle_external_input(
+        state,
+        {
+            "text": "두 번째 웹 입력",
+            "caller_info": {"source": "browser", "display_name": "Jubok Kim"},
+        },
+    )
+    assert slack_client.chat_delete.call_count == first_turn_delete_count
+
+    await manager._dispatch_current(state, "on_thinking", "두 번째 검토", 201)
+    await manager._handle_complete(state, {})
+
+    slack_client.chat_delete.assert_has_calls([
+        call(channel="C123", ts="placeholder-a-2"),
+        call(channel="C123", ts="board-2"),
+    ])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 요약
- 외부 SSE listener turn 콜백을 으로 생성하도록 변경했습니다.
- 외부 turn마다 placeholder A와 ActivityBoard placeholder B를 만들고 complete 시 cleanup으로 정리합니다.
- session_listener 회귀 테스트를 clean 모드 기준으로 갱신하고 다중 turn cleanup 격리를 추가했습니다.

## 검증
- ============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/eias/seosoyoung-workspace/roselin_codex/.projects/seosoyoung--session-listener-clean-mode
configfile: pytest.ini
plugins: timeout-2.4.0, xdist-3.8.0, anyio-4.13.0, asyncio-1.4.0
timeout: 60.0s
timeout method: signal
timeout func_only: False
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
created: 4/4 workers
4 workers [1285 items]

........................................................................ [  5%]
........................................................................ [ 11%]
..................................s.sss.ss.............................. [ 16%]
...................................ssss...sss.ss...s.sss..s.ss.s..ss...s [ 22%]
s....................................................................... [ 28%]
........................................................................ [ 33%]
........................................................................ [ 39%]
........................................................................ [ 44%]
........................................................................ [ 50%]
........................................................................ [ 56%]
...............s........................................................ [ 61%]
........................................................................ [ 67%]
........................................................................ [ 72%]
........................................................................ [ 78%]
........................................................................ [ 84%]
........................................................................ [ 89%]
........................................................................ [ 95%]
.............................................................            [100%]
======================= 1257 passed, 28 skipped in 8.31s ======================= → 1257 passed, 28 skipped
-  → 통과
-  → 통과

## 사용자 검증
- 머지·배포 후 실제 외부 위임 turn에서 ActivityBoard 한 장에 누적·갱신되는지 확인 필요