### PR TITLE
feat: route Slack users to session folders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 SLACK_BOT_TOKEN=xoxb-...
 SLACK_APP_TOKEN=xapp-...
+SLACK_USER_FOLDER_MAP={"U0A9ELR53R8":"9374c7e6-df4c-4adb-b27b-7787216698c4"}
 LOG_PATH=D:\soyoung_root\seosoyoung_runtime\logs
 SESSION_PATH=D:\soyoung_root\seosoyoung_runtime\sessions
 ALLOWED_USERS=eias

--- a/src/seosoyoung/slackbot/config.py
+++ b/src/seosoyoung/slackbot/config.py
@@ -5,6 +5,8 @@
 - 그 외 설정: @dataclass 하위 그룹 (모듈 로드 시 평가)
 """
 
+import json
+import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -13,6 +15,10 @@ from typing import List
 from dotenv import find_dotenv, load_dotenv
 
 load_dotenv(find_dotenv(usecwd=True))
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SOULSTREAM_FOLDER_ID = "claude"
 
 
 class ConfigurationError(Exception):
@@ -42,6 +48,48 @@ def _parse_bool(value: str | None, default: bool = False) -> bool:
     return value.lower() == "true"
 
 
+def parse_slack_user_folder_map(raw: str | None) -> dict[str, str]:
+    """SLACK_USER_FOLDER_MAP JSON 문자열을 user_id → folder_id dict로 파싱"""
+    if raw is None or not raw.strip():
+        return {}
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as e:
+        logger.error(f"SLACK_USER_FOLDER_MAP 파싱 실패: {e}")
+        return {}
+
+    if not isinstance(parsed, dict):
+        logger.error("SLACK_USER_FOLDER_MAP 파싱 실패: JSON object가 아닙니다")
+        return {}
+
+    result: dict[str, str] = {}
+    for user_id, folder_id in parsed.items():
+        if (
+            not isinstance(user_id, str)
+            or not isinstance(folder_id, str)
+            or not user_id.strip()
+            or not folder_id.strip()
+        ):
+            logger.error(
+                "SLACK_USER_FOLDER_MAP 파싱 실패: "
+                "Slack user_id와 folder_id는 비어 있지 않은 문자열이어야 합니다"
+            )
+            return {}
+        result[user_id.strip()] = folder_id.strip()
+
+    return result
+
+
+def resolve_folder_id(
+    user_id: str,
+    mapping: dict[str, str],
+    default: str | None,
+) -> str | None:
+    """Slack user_id에 해당하는 Soulstream folder_id를 반환"""
+    return mapping.get(user_id) or default
+
+
 @dataclass
 class SlackConfig:
     """Slack 연결 설정"""
@@ -52,6 +100,11 @@ class SlackConfig:
     operator_user_id: str = os.environ["OPERATOR_USER_ID"]
     # 미설정 시 빈 문자열 → 슬랙 버튼 미표시
     workspace_url: str = os.getenv("SLACK_WORKSPACE_URL", "")
+    user_folder_map: dict[str, str] = field(
+        default_factory=lambda: parse_slack_user_folder_map(
+            os.getenv("SLACK_USER_FOLDER_MAP")
+        )
+    )
 
 
 @dataclass

--- a/src/seosoyoung/slackbot/handlers/mention.py
+++ b/src/seosoyoung/slackbot/handlers/mention.py
@@ -6,7 +6,11 @@
 import re
 import logging
 
-from seosoyoung.slackbot.config import Config
+from seosoyoung.slackbot.config import (
+    Config,
+    DEFAULT_SOULSTREAM_FOLDER_ID,
+    resolve_folder_id,
+)
 from seosoyoung.slackbot.reflect import reflect
 from seosoyoung.slackbot.slack import download_files_sync, build_file_context
 from seosoyoung.slackbot.slack.message_formatter import format_slack_message
@@ -100,6 +104,14 @@ def _get_channel_messages(client, channel: str, limit: int = 20) -> list[dict]:
     except Exception as e:
         logger.warning(f"채널 히스토리 가져오기 실패: {e}")
         return []
+
+
+def _get_user_folder_map() -> dict[str, str]:
+    """Config.slack.user_folder_map을 dict로 반환"""
+    mapping = getattr(getattr(Config, "slack", None), "user_folder_map", {})
+    if isinstance(mapping, dict):
+        return mapping
+    return {}
 
 
 _ADMIN_COMMANDS = frozenset({
@@ -440,6 +452,11 @@ def create_session_and_run_claude(
         avatar_url=user_info.get("avatar_url") or None,
         email=user_info.get("email") or None,
     )
+    folder_id = resolve_folder_id(
+        user_id,
+        _get_user_folder_map(),
+        DEFAULT_SOULSTREAM_FOLDER_ID,
+    )
 
     # Claude 실행 (placeholder → 콜백 빌드 → executor → cleanup)
     run_with_event_callbacks(
@@ -456,6 +473,7 @@ def create_session_and_run_claude(
             user_message=clean_text,
             on_result=on_result,
             caller_info=caller_info,
+            folder_id=folder_id,
         ),
         on_compact_wrapper=lambda cb: wrap_on_compact_with_memory(
             cb, pm, session_thread_ts,

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -163,6 +163,63 @@ class TestConfigBoolParsing:
         assert config_module.Config.debug is False
 
 
+class TestSlackUserFolderMap:
+    """Slack user_id별 Soulstream folder_id 설정 테스트"""
+
+    def test_user_folder_map_default_empty(self):
+        """SLACK_USER_FOLDER_MAP 미설정 시 빈 dict"""
+        config_module = reload_config_with_env({})
+
+        assert config_module.Config.slack.user_folder_map == {}
+
+    def test_user_folder_map_blank_is_empty_without_error(self, caplog):
+        """빈 문자열은 조용히 빈 dict"""
+        config_module = reload_config_with_env({"SLACK_USER_FOLDER_MAP": ""})
+
+        assert config_module.Config.slack.user_folder_map == {}
+        assert "SLACK_USER_FOLDER_MAP" not in caplog.text
+
+    def test_user_folder_map_valid_json(self):
+        """JSON object를 Slack user_id → folder_id dict로 파싱"""
+        folder_id = "9374c7e6-df4c-4adb-b27b-7787216698c4"
+        config_module = reload_config_with_env({
+            "SLACK_USER_FOLDER_MAP": f'{{"U0A9ELR53R8":"{folder_id}"}}',
+        })
+
+        assert config_module.Config.slack.user_folder_map == {
+            "U0A9ELR53R8": folder_id,
+        }
+
+    def test_user_folder_map_invalid_json_logs_error(self, caplog):
+        """잘못된 JSON은 빈 dict + ERROR 로그"""
+        caplog.set_level("ERROR")
+
+        config_module = reload_config_with_env({
+            "SLACK_USER_FOLDER_MAP": "{not-json",
+        })
+
+        assert config_module.Config.slack.user_folder_map == {}
+        assert "SLACK_USER_FOLDER_MAP 파싱 실패" in caplog.text
+
+    def test_resolve_folder_id_uses_mapping(self):
+        """매핑된 사용자는 해당 folder_id 반환"""
+        from seosoyoung.slackbot.config import resolve_folder_id
+
+        folder_id = "9374c7e6-df4c-4adb-b27b-7787216698c4"
+
+        assert resolve_folder_id(
+            "U0A9ELR53R8",
+            {"U0A9ELR53R8": folder_id},
+            "claude",
+        ) == folder_id
+
+    def test_resolve_folder_id_falls_back_to_default(self):
+        """매핑 없는 사용자는 기본 folder_id 반환"""
+        from seosoyoung.slackbot.config import resolve_folder_id
+
+        assert resolve_folder_id("U_OTHER", {}, "claude") == "claude"
+
+
 # NOTE: TestConfigListParsing (translate.channels) 제거됨
 # Config.translate는 플러그인 아키텍처로 이동하여 Config에서 제거됨
 # 채널 리스트 파싱은 이제 plugins/translate/plugin.py에서 YAML config로 처리

--- a/tests/handlers/test_dm_handler.py
+++ b/tests/handlers/test_dm_handler.py
@@ -176,6 +176,52 @@ class TestDmFirstMessage:
         # Claude 실행이 호출되어야 함
         deps["run_claude_in_session"].assert_called_once()
 
+    @patch("seosoyoung.slackbot.handlers.mention._get_channel_messages", return_value=[])
+    @patch("seosoyoung.slackbot.handlers.mention.Config")
+    @patch("seosoyoung.slackbot.handlers.message.Config")
+    def test_dm_first_message_mapped_user_passes_folder_id(
+        self, mock_msg_config, mock_mention_config, mock_get_msgs
+    ):
+        """DM 첫 메시지 + 매핑된 사용자 → 매핑 folder_id로 실행"""
+        folder_id = "9374c7e6-df4c-4adb-b27b-7787216698c4"
+        mock_msg_config.BOT_USER_ID = "B_BOT"
+        mock_msg_config.TRANSLATE_CHANNELS = []
+        mock_msg_config.CHANNEL_OBSERVER_TRIGGER_WORDS = []
+        mock_mention_config.CHANNEL_OBSERVER_CHANNELS = []
+        mock_mention_config.slack.user_folder_map = {"U0A9ELR53R8": folder_id}
+
+        from seosoyoung.slackbot.handlers.message import register_message_handlers
+
+        mock_session = MagicMock(source_type="thread", last_seen_ts="", message_count=0)
+        deps = _make_deps(
+            get_user_role=MagicMock(return_value={
+                "username": "tester",
+                "role": "admin",
+                "user_id": "U0A9ELR53R8",
+                "allowed_tools": [],
+            })
+        )
+        deps["session_manager"].create.return_value = mock_session
+
+        handlers = _register_and_capture(register_message_handlers, deps)
+
+        event = {
+            "user": "U0A9ELR53R8",
+            "channel": "D_DM",
+            "channel_type": "im",
+            "text": "안녕하세요 질문이 있습니다",
+            "ts": "1234.5678",
+        }
+
+        say = MagicMock()
+        client = MagicMock()
+        client.chat_postMessage.return_value = {"ts": "reply_ts"}
+
+        handlers["message"](event, say, client)
+
+        deps["run_claude_in_session"].assert_called_once()
+        assert deps["run_claude_in_session"].call_args.kwargs["folder_id"] == folder_id
+
     @patch("seosoyoung.slackbot.handlers.message.Config")
     def test_dm_empty_message_ignored(self, mock_config):
         """빈 DM 메시지 → 무시"""

--- a/tests/handlers/test_thread_mention.py
+++ b/tests/handlers/test_thread_mention.py
@@ -309,6 +309,95 @@ class TestMentionHandlerThreadSession:
             # 세션 생성 경로로 진행
             handler_deps["session_manager"].create.assert_called_once()
 
+    def test_channel_mention_mapped_user_passes_folder_id(self, handler_deps):
+        """새 채널 멘션 + 매핑된 사용자 → 매핑 folder_id로 실행"""
+        folder_id = "9374c7e6-df4c-4adb-b27b-7787216698c4"
+        handler_deps["session_manager"].get.return_value = None
+        mock_session = MagicMock()
+        mock_session.message_count = 0
+        handler_deps["session_manager"].create.return_value = mock_session
+
+        with patch("seosoyoung.slackbot.handlers.mention.process_thread_message") as mock_process, \
+             patch("seosoyoung.slackbot.handlers.mention._get_channel_messages", return_value=[]), \
+             patch("seosoyoung.slackbot.handlers.mention.Config") as mock_config:
+            mock_config.slack.user_folder_map = {"U0A9ELR53R8": folder_id}
+
+            from seosoyoung.slackbot.handlers.mention import register_mention_handlers
+
+            app = MagicMock()
+            captured_handler = None
+
+            def capture_handler(event_type):
+                def decorator(func):
+                    nonlocal captured_handler
+                    captured_handler = func
+                    return func
+                return decorator
+
+            app.event = capture_handler
+            register_mention_handlers(app, handler_deps)
+
+            event = {
+                "user": "U0A9ELR53R8",
+                "text": "<@BOT> 새 질문",
+                "channel": "C123",
+                "ts": "ts_1",
+            }
+
+            say = MagicMock()
+            client = MagicMock()
+            client.chat_postMessage.return_value = {"ts": "msg_ts"}
+
+            captured_handler(event, say, client)
+
+            mock_process.assert_not_called()
+            handler_deps["run_claude_in_session"].assert_called_once()
+            assert handler_deps["run_claude_in_session"].call_args.kwargs["folder_id"] == folder_id
+
+    def test_channel_mention_unmapped_user_passes_default_folder_id(self, handler_deps):
+        """새 채널 멘션 + 매핑 없는 사용자 → 기본 claude folder_id로 실행"""
+        handler_deps["session_manager"].get.return_value = None
+        mock_session = MagicMock()
+        mock_session.message_count = 0
+        handler_deps["session_manager"].create.return_value = mock_session
+
+        with patch("seosoyoung.slackbot.handlers.mention.process_thread_message") as mock_process, \
+             patch("seosoyoung.slackbot.handlers.mention._get_channel_messages", return_value=[]), \
+             patch("seosoyoung.slackbot.handlers.mention.Config") as mock_config:
+            mock_config.slack.user_folder_map = {"U0A9ELR53R8": "mapped-folder"}
+
+            from seosoyoung.slackbot.handlers.mention import register_mention_handlers
+
+            app = MagicMock()
+            captured_handler = None
+
+            def capture_handler(event_type):
+                def decorator(func):
+                    nonlocal captured_handler
+                    captured_handler = func
+                    return func
+                return decorator
+
+            app.event = capture_handler
+            register_mention_handlers(app, handler_deps)
+
+            event = {
+                "user": "U_OTHER",
+                "text": "<@BOT> 새 질문",
+                "channel": "C123",
+                "ts": "ts_1",
+            }
+
+            say = MagicMock()
+            client = MagicMock()
+            client.chat_postMessage.return_value = {"ts": "msg_ts"}
+
+            captured_handler(event, say, client)
+
+            mock_process.assert_not_called()
+            handler_deps["run_claude_in_session"].assert_called_once()
+            assert handler_deps["run_claude_in_session"].call_args.kwargs["folder_id"] == "claude"
+
 
     def test_thread_mention_with_session_restart_pending(self, handler_deps):
         """스레드 멘션 + 세션 있음 + 재시작 대기 → 안내 메시지"""


### PR DESCRIPTION
## Summary
- Parse SLACK_USER_FOLDER_MAP as Slack user_id to Soulstream folder_id mapping
- Pass resolved folder_id for new Slack mention and DM sessions
- Keep existing thread follow-up sessions and channel_observer paths unchanged

## Verification
- .venv/bin/python -m pytest --timeout=60 tests/core/test_config.py tests/handlers/test_thread_mention.py tests/handlers/test_dm_handler.py
- .venv/bin/python -m pytest --timeout=60
- git diff --check

## User Verification After Merge
- Own account mention stays in the default claude folder
- U0A9ELR53R8 mention enters folder 9374c7e6-df4c-4adb-b27b-7787216698c4

## Notes
- Runtime deployment env still needs SLACK_USER_FOLDER_MAP to be set by the delegator before restart.