### PR TITLE
fix: filter internal debug messages from Slack

### DIFF
--- a/src/seosoyoung/slackbot/soulstream/debug_policy.py
+++ b/src/seosoyoung/slackbot/soulstream/debug_policy.py
@@ -1,0 +1,18 @@
+"""Soulstream debug 이벤트의 Slack 게시 허용 정책."""
+
+import re
+
+
+_KOREAN_USAGE_WARNING = re.compile(r"⚠️ .+ 사용량 중 \d+%를 넘었습니다")
+
+
+def is_user_facing_debug_message(message: str) -> bool:
+    """사용자가 대응해야 하는 레거시 rate-limit 경고만 허용한다."""
+    stripped = message.strip()
+    normalized = stripped.casefold()
+
+    if normalized.startswith("rate limit warning:"):
+        return True
+    if normalized.startswith("⚠️ rate_limit"):
+        return True
+    return _KOREAN_USAGE_WARNING.fullmatch(stripped) is not None

--- a/src/seosoyoung/slackbot/soulstream/executor.py
+++ b/src/seosoyoung/slackbot/soulstream/executor.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from seosoyoung.slackbot.reflect import reflect
+from seosoyoung.slackbot.soulstream.debug_policy import is_user_facing_debug_message
 from seosoyoung.slackbot.soulstream.engine_types import ClaudeResult, CompactCallback
 from seosoyoung.slackbot.soulstream.intervention import InterventionManager
 from seosoyoung.slackbot.soulstream.result_processor import ResultProcessor
@@ -542,9 +543,12 @@ class ClaudeExecutor:
         """Remote 모드: Soulstream 서버에 실행을 위임 (per-session)"""
         adapter = self._get_service_adapter()
 
-        # debug 콜백: rate_limit 경고 등을 슬랙 스레드에 전송
+        # 사용자 대응이 필요한 레거시 rate-limit debug만 슬랙 스레드에 전송
         async def on_debug(message: str) -> None:
             if presentation is None:
+                return
+            if not is_user_facing_debug_message(message):
+                logger.debug("[Remote] Slack 게시에서 내부 debug 제외: %s", message)
                 return
             try:
                 presentation.client.chat_postMessage(

--- a/tests/soulstream/test_debug_policy.py
+++ b/tests/soulstream/test_debug_policy.py
@@ -1,0 +1,115 @@
+"""Slack에 게시 가능한 Soulstream debug 메시지 정책 테스트."""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from seosoyoung.slackbot.presentation.types import PresentationContext
+from seosoyoung.slackbot.soulstream.debug_policy import is_user_facing_debug_message
+from seosoyoung.slackbot.soulstream.engine_types import ClaudeResult
+from seosoyoung.slackbot.soulstream.executor import ClaudeExecutor
+from seosoyoung.slackbot.soulstream.session import SessionManager, SessionRuntime
+
+
+def _make_executor(tmp_path):
+    return ClaudeExecutor(
+        session_manager=SessionManager(session_dir=tmp_path / "sessions"),
+        session_runtime=SessionRuntime(),
+        restart_manager=MagicMock(),
+        send_long_message=MagicMock(),
+        send_restart_confirmation=MagicMock(),
+        update_message_fn=MagicMock(),
+    )
+
+
+def _make_pctx() -> PresentationContext:
+    return PresentationContext(
+        channel="C123",
+        thread_ts="1234.5678",
+        msg_ts="1234.0001",
+        say=MagicMock(),
+        client=MagicMock(),
+        effective_role="admin",
+        session_id="sess-001",
+    )
+
+
+async def _noop_compact(_trigger, _message):
+    pass
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "rate limit warning: 80% used",
+        "⚠️ rate_limit `rate_limited` (CLI 자체 처리 중, type=five_hour)",
+        "⚠️ 주간 사용량 중 80%를 넘었습니다",
+    ],
+)
+def test_user_facing_rate_limit_debug_is_allowed(message):
+    assert is_user_facing_debug_message(message) is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Ignored Codex app-server notification: configWarning",
+        "Ignored Codex app-server notification: future/unknownDebug",
+        "[low:rate_limit] internal notification",
+        "ordinary debug info",
+        "",
+    ],
+)
+def test_internal_or_unknown_debug_is_rejected(message):
+    assert is_user_facing_debug_message(message) is False
+
+
+def test_internal_and_unknown_debug_not_sent_to_slack(tmp_path):
+    """Codex 내부 상태와 미래 unknown debug는 Slack 게시 경계를 통과하지 않음"""
+    executor = _make_executor(tmp_path)
+    executor.session_manager.create(
+        thread_ts="1234.5678",
+        channel_id="C123",
+        user_id="U123",
+        role="admin",
+    )
+    pctx = _make_pctx()
+    captured_on_debug = None
+
+    async def mock_execute(**kwargs):
+        nonlocal captured_on_debug
+        captured_on_debug = kwargs.get("on_debug")
+        return ClaudeResult(success=True, output="done", session_id="sess-1")
+
+    mock_adapter = MagicMock()
+    mock_adapter.execute = mock_execute
+
+    with patch.object(executor, "_get_service_adapter", return_value=mock_adapter):
+        executor._execute_remote(
+            "1234.5678", "hello",
+            on_compact=_noop_compact,
+            presentation=pctx,
+            session_id="sess-001",
+            user_message=None,
+            on_result=None,
+        )
+
+    assert captured_on_debug is not None
+    internal_messages = [
+        "Ignored Codex app-server notification: configWarning",
+        "Ignored Codex app-server notification: remoteControl/status/changed",
+        "Ignored Codex app-server notification: mcpServer/startupStatus/updated",
+        "Ignored Codex app-server notification: thread/tokenUsage/updated",
+        "Ignored Codex app-server notification: account/rateLimits/updated",
+        "Ignored Codex app-server notification: future/unknownDebug",
+    ]
+
+    loop = asyncio.new_event_loop()
+    try:
+        for message in internal_messages:
+            loop.run_until_complete(captured_on_debug(message))
+    finally:
+        loop.close()
+
+    pctx.client.chat_postMessage.assert_not_called()

--- a/tests/soulstream/test_executor_remote.py
+++ b/tests/soulstream/test_executor_remote.py
@@ -357,7 +357,6 @@ class TestExecutorRemoteDebug:
             text="rate limit warning: 80% used",
         )
 
-
 class TestGetServiceAdapter:
     """_get_service_adapter 매번 새 인스턴스 생성 테스트"""
 

--- a/tests/soulstream/test_integration_remote.py
+++ b/tests/soulstream/test_integration_remote.py
@@ -433,7 +433,7 @@ class TestIntegrationDebugEvents:
             nonlocal captured_on_debug
             captured_on_debug = kwargs.get("on_debug")
             if captured_on_debug:
-                await captured_on_debug("debug info")
+                await captured_on_debug("rate limit warning: 80% used")
             return ClaudeResult(success=True, output="still works", session_id="s-1")
 
         mock_adapter = MagicMock()


### PR DESCRIPTION
## 요약
- Slack 게시 직전에 사용자 대응 rate-limit debug만 명시적으로 허용
- Codex app-server 내부 알림과 미래 unknown debug는 로그에만 남김
- 정상 진행·결과·credential alert 경로 유지

## 검증
- 전체: 1,278 passed, 28 skipped, warnings 0
- 위임자 핵심 회귀 재검증: 13 passed
- P0/P1: 0